### PR TITLE
Add kube-linter to GitHub actions

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -1,0 +1,56 @@
+name: Check Kubernetes YAMLs with kube-linter
+
+on:
+  # Note that both `push` and `pull_request` triggers should be present for GitHub to consistently present kube-linter
+  # SARIF reports.
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+jobs:
+  scan:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # This prepares directory where github/codeql-action/upload-sarif@v1 looks up report files by default.
+      - name: Create ../results directory for SARIF report files
+        shell: bash
+        run: mkdir -p ../results kustomizedfiles
+
+      - name: Setup Kustomize
+        uses: multani/action-setup-kustomize@v1
+        with:
+          version: 5.6.0
+
+      - name: Run kustomize build
+        run: |
+          find argo-cd-apps components -name 'kustomization.yaml' \
+            | \
+            xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo $dir | tr / -)-kustomization.yaml; if ! log=$(kustomize build --enable-helm "$dir" -o "kustomizedfiles/$output_file" 2>&1); then echo "Error when running kustomize build for $dir: $log" && exit 1;fi'
+
+      - name: Scan yaml files with kube-linter
+        uses: stackrox/kube-linter-action@v1.0.4
+        id: kube-linter-action-scan
+        with:
+          version: v0.7.2
+          # Adjust this directory to the location where your kubernetes resources and helm charts are located.
+          directory: kustomizedfiles
+          # The following two settings make kube-linter produce scan analysis in SARIF format which would then be
+          # made available in GitHub UI via upload-sarif action below.
+          format: sarif
+          output-file: ../results/kube-linter.sarif
+        # The following line prevents aborting the workflow immediately in case your files fail kube-linter checks.
+        # This allows the following upload-sarif action to still upload the results to your GitHub repo.
+        continue-on-error: true
+
+      - name: Upload SARIF report files to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+
+      # Ensure the workflow eventually fails if files did not pass kube-linter checks.
+      - name: Verify kube-linter-action succeeded
+        shell: bash
+        run: |
+          echo "If this step fails, kube-linter found issues. Check the output of the scan step above."
+          [[ "${{ steps.kube-linter-action-scan.outcome }}" == "success" ]]


### PR DESCRIPTION
This is the same workflow as used in the infra-deployments repo, with the exception that there is no path exclusion implemented in the `kustomize build` action. Linting and testing Kustomize builds is necessary for the Kustomization files in this repo.