### PR TITLE
KFLUXDP-403: Deploy Apache Devlake in Konflux internal staging 

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -41,10 +41,11 @@ jobs:
         run: |
           find argo-cd-apps components -name 'kustomization.yaml' \
             ! -path 'components/kargo/*' \
+            ! -path 'components/konflux-devlake/*' \
             | xargs -I {} -n1 -P8 bash -c '
               dir=$(dirname "{}")
               output_file=$(echo $dir | tr / -)-kustomization.yaml
-              if ! log=$(kustomize build "$dir" -o "kustomizedfiles/$output_file" 2>&1); then
+              if ! log=$(kustomize build --enable-helm "$dir" -o "kustomizedfiles/$output_file" 2>&1); then
                 echo "Error when running kustomize build for $dir: $log"
                 exit 1
               fi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,3 +24,7 @@
 
 # Owners for smee
 /components/smee/ @ifireball @gbenhaim @amisstea @yftacherzog @avi-biton
+
+# Owners for konflux-devlake
+/components/konflux-devlake/ @ascerra @flacatus @psturc @Dannyb48
+/argo-cd-apps/base/internal/konflux-devlake/ @ascerra @flacatus @psturc @Dannyb48

--- a/argo-cd-apps/base/internal/konflux-devlake/appset.yaml
+++ b/argo-cd-apps/base/internal/konflux-devlake/appset.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-devlake
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/konflux-devlake
+          environment: ""
+  template:
+    metadata:
+      name: konflux-devlake
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+      destination:
+        namespace: konflux-devlake
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/internal/konflux-devlake/kustomization.yaml
+++ b/argo-cd-apps/base/internal/konflux-devlake/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset.yaml
+

--- a/argo-cd-apps/base/internal/kustomization.yaml
+++ b/argo-cd-apps/base/internal/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - kargo
   - cert-manager
   - konflux-support-ops
+  - konflux-devlake

--- a/components/konflux-devlake/base/kustomization.yaml
+++ b/components/konflux-devlake/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: konflux-devlake
+
+resources:
+- namespace.yaml

--- a/components/konflux-devlake/base/namespace.yaml
+++ b/components/konflux-devlake/base/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konflux-devlake

--- a/components/konflux-devlake/internal-staging/external-secrets/konflux-devlake-secrets.yaml
+++ b/components/konflux-devlake/internal-staging/external-secrets/konflux-devlake-secrets.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: konflux-devlake-secrets
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/qe/konflux-devlake
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: konflux-devlake-secrets

--- a/components/konflux-devlake/internal-staging/external-secrets/kustomization.yaml
+++ b/components/konflux-devlake/internal-staging/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - konflux-devlake-secrets.yaml

--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -1,0 +1,87 @@
+---
+lake:
+  encryptionSecret:
+    secretName: konflux-devlake-secrets
+    autoCreateSecret: false
+  securityContext: {}
+  containerSecurityContext: {}
+  envs:
+    REMOTE_PLUGIN_DIR: ""
+    DISABLED_REMOTE_PLUGINS: "true"
+    API_REQUESTS_PER_HOUR: "100000"
+    LOGGING_DIR: "/tmp"
+  envFrom:
+    - secretRef:
+        name: konflux-devlake-secrets
+
+mysql:
+  useExternal: true
+  externalServer: "kubernetes.default.svc.cluster.local"  # K8s API - always available
+  externalPort: 443  # HTTPS port - always open
+
+grafana:
+  image:
+    repository: devlake.docker.scarf.sh/apache/devlake-dashboard
+    tag: v1.0.2
+  podSecurityContext: {}
+  securityContext:
+    fsGroup: null
+    runAsGroup: null
+    runAsUser: null
+  initChownData:
+    enabled: false
+  envFromSecrets:
+    - name: "konflux-devlake-secrets"
+  env:
+    TZ: "UTC"
+    GF_SERVER_SERVE_FROM_SUBPATH: "true"
+    GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s/grafana/"
+  grafana.ini:
+    server:
+      serve_from_subpath: "true"
+      root_url: "%(protocol)s://%(domain)s/grafana/"
+    auth.google:
+      enabled: true
+      client_id: "${GF_AUTH_GOOGLE_CLIENT_ID}"  # Set via secret
+      client_secret: "${GF_AUTH_GOOGLE_CLIENT_SECRET}"  # Set via secret
+      scopes: "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email openid"
+      auth_url: "https://accounts.google.com/o/oauth2/auth"
+      token_url: "https://accounts.google.com/o/oauth2/token"
+      api_url: "https://www.googleapis.com/oauth2/v1/userinfo"
+      allowed_domains: "redhat.com"
+      allow_sign_up: true
+ui:
+  securityContext: {}
+  containerSecurityContext: {}
+  basicAuth:
+    enabled: false
+    autoCreateSecret: true
+    secretName: ""
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: false
+
+option:
+  autoCreateSecret: false
+  database: mysql
+  connectionSecretName: "konflux-devlake-secrets"
+
+extraResources:
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: konflux-devlake-ui
+    spec:
+      to:
+        kind: Service
+        name: konflux-devlake-ui
+        weight: 100
+      port:
+        targetPort: ui
+      tls:
+        termination: edge
+        insecureEdgeTerminationPolicy: Redirect
+      wildcardPolicy: None

--- a/components/konflux-devlake/internal-staging/kustomization.yaml
+++ b/components/konflux-devlake/internal-staging/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: konflux-devlake
+
+resources:
+- ../base
+- external-secrets
+
+helmCharts:
+- name: devlake
+  repo: https://apache.github.io/incubator-devlake-helm-chart
+  version: 1.0.2
+  releaseName: konflux-devlake
+  namespace: konflux-devlake
+  valuesFile: helm-values.yaml
+  includeCRDs: true
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "-1"

--- a/components/konflux-devlake/kustomization.yaml
+++ b/components/konflux-devlake/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./base


### PR DESCRIPTION
As part of [KFLUXDP-403](https://issues.redhat.com/browse/KFLUXDP-403), this Pull Request introduces devlake helm charts in stage for now

The deployment enables monitoring of:

* Konflux defects
* DORA metrics
* Quality status
* Other relevant engineering productivity indicators
