### PR TITLE
Set ApplicationSet default environment to empty string

### DIFF
--- a/argo-cd-apps/base/external/smee/appset.yaml
+++ b/argo-cd-apps/base/external/smee/appset.yaml
@@ -8,7 +8,7 @@ spec:
     - clusters:
         values:
           sourceRoot: components/smee
-          environment: base
+          environment: ""
           clusterName: ""
   template:
     metadata:

--- a/argo-cd-apps/base/internal/internal-services/appset.yaml
+++ b/argo-cd-apps/base/internal/internal-services/appset.yaml
@@ -8,7 +8,7 @@ spec:
     - clusters:
         values:
           sourceRoot: components/internal-services
-          environment: "staging"
+          environment: ""
   template:
     metadata:
       name: internal-services

--- a/argo-cd-apps/base/internal/openshift-pipelines/appset.yaml
+++ b/argo-cd-apps/base/internal/openshift-pipelines/appset.yaml
@@ -8,7 +8,7 @@ spec:
     - clusters:
         values:
           sourceRoot: components/openshift-pipelines
-          environment: base
+          environment: ""
           clusterName: ""
   template:
     metadata:


### PR DESCRIPTION
The environment is getting changed by a patch to the right value, i.e.

* internal-staging
* internal-production
* external-staging
* external-production

Change the ApplicationSets to have nothing as default to remove confusion but also in case we do not patch it, it will not deploy thing from unexpected folder as the root folder of components usually does not contains kustomization.yaml.