### PR TITLE
Fix openshift-pipelines application name

### DIFF
--- a/argo-cd-apps/base/internal/openshift-pipelines/appset.yaml
+++ b/argo-cd-apps/base/internal/openshift-pipelines/appset.yaml
@@ -12,7 +12,7 @@ spec:
           clusterName: ""
   template:
     metadata:
-      name: openshift-pipelines-{{values.clusterName}}
+      name: openshift-pipelines
     spec:
       project: default
       source:


### PR DESCRIPTION
We do not need cluster name since we deploy this to the in-cluster cluster.