### PR TITLE
Normalise application names

### DIFF
--- a/argo-cd-apps/base/all-clusters/cluster-secret-store/cluster-secret-store.yaml
+++ b/argo-cd-apps/base/all-clusters/cluster-secret-store/cluster-secret-store.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       project: default
       source:
-        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        path: '{{values.sourceRoot}}/{{values.environment}}'
         repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
         targetRevision: main
       destination:

--- a/argo-cd-apps/base/all-clusters/iam/iam.yaml
+++ b/argo-cd-apps/base/all-clusters/iam/iam.yaml
@@ -11,7 +11,7 @@ spec:
           environment: ""
   template:
     metadata:
-      name: iam
+      name: iam-{{nameNormalized}}
     spec:
       project: default
       source:

--- a/argo-cd-apps/base/external/smee/appset.yaml
+++ b/argo-cd-apps/base/external/smee/appset.yaml
@@ -12,7 +12,7 @@ spec:
           clusterName: ""
   template:
     metadata:
-      name: smee-{{values.clusterName}}
+      name: smee-{{nameNormalized}}
     spec:
       project: default
       source:

--- a/argo-cd-apps/base/internal/internal-services/appset.yaml
+++ b/argo-cd-apps/base/internal/internal-services/appset.yaml
@@ -11,7 +11,7 @@ spec:
           environment: ""
   template:
     metadata:
-      name: internal-services
+      name: internal-services-{{nameNormalized}}
     spec:
       project: default
       source:

--- a/argo-cd-apps/base/internal/openshift-pipelines/appset.yaml
+++ b/argo-cd-apps/base/internal/openshift-pipelines/appset.yaml
@@ -12,7 +12,7 @@ spec:
           clusterName: ""
   template:
     metadata:
-      name: openshift-pipelines
+      name: openshift-pipelines-{{nameNormalized}}
     spec:
       project: default
       source:


### PR DESCRIPTION
Align all the created application to have same name which include the name of the cluster to make it more clear that we deploy in-cluster.

Also fix clustersecretstore component path.