### PR TITLE
allow internal-services to use secret store

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -28,3 +28,4 @@ spec:
   conditions:
     - namespaces:
         - group-sync-operator
+        - internal-services


### PR DESCRIPTION
- using cluster store "appsre-stonesoup-vault" is not allowed from namespace "internal-services": denied by spec.condition