### PR TITLE
Create applicationset in ArgoCD namespace

### DIFF
--- a/argo-cd-apps/overlays/external-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/external-production/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: argocd-local
 resources:
   - ../../base/all-clusters
   - ../../base/external

--- a/argo-cd-apps/overlays/external-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/external-staging/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: argocd-local
 resources:
   - ../../base/all-clusters
   - ../../base/external

--- a/argo-cd-apps/overlays/internal-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/internal-production/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: argocd-local
 resources:
   - ../../base/all-clusters
   - ../../base/internal


### PR DESCRIPTION
We do not want the applicationset in default ns, we want them in same ns as ArgoCD. Change all overlays except internal staging. Once proven to work we will do internal staging at same time we redeploy this cluster.