### PR TITLE
feat(RELEASE-1879): add internal-services prod resources

### DIFF
--- a/components/internal-services/internal-production/config/internal-services-config.yaml
+++ b/components/internal-services/internal-production/config/internal-services-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: InternalServicesConfig
+metadata:
+  name: config
+spec:
+  allowList:
+  - rhtap-releng-tenant
+  - rh-managed-cnv-fbc-tenant
+  - rh-managed-red-hat-acm-tenant
+  debug: true
+  volumeClaim:
+    name: pipeline
+    size: 1Gi

--- a/components/internal-services/internal-production/config/kustomization.yaml
+++ b/components/internal-services/internal-production/config/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - internal-services-config.yaml

--- a/components/internal-services/internal-production/kustomization.yaml
+++ b/components/internal-services/internal-production/kustomization.yaml
@@ -6,3 +6,9 @@ resources:
 
   # External Secrets
   - es/
+  # InternalServicesConfig
+  - config/
+  # NetworkPolicy
+  - networkpolicy/
+  # Signing ConfigMaps
+  - signing/

--- a/components/internal-services/internal-production/networkpolicy/kustomization.yaml
+++ b/components/internal-services/internal-production/networkpolicy/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - network_policy.yaml

--- a/components/internal-services/internal-production/networkpolicy/network_policy.yaml
+++ b/components/internal-services/internal-production/networkpolicy/network_policy.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-external-cluster
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Egress
+  egress:
+    - {}  # allow all egress

--- a/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-openshifthosted.yaml
+++ b/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-openshifthosted.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: production
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-openshifthosted"
+data:
+  PYXIS_URL: "https://pyxis.engineering.redhat.com"
+  SIG_KEY_ID: "B906BA72"
+  SIG_KEY_NAME: "openshifthosted"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-redhatbeta2.yaml
+++ b/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-redhatbeta2.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: production
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatbeta2"
+data:
+  PYXIS_URL: "https://pyxis.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/F21541EB SHA-256"
+  SIG_KEY_NAME: "beta2"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-redhatrelease2.yaml
+++ b/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-redhatrelease2.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: production
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatrelease2"
+data:
+  PYXIS_URL: "https://pyxis.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/FD431D51 SHA-256"
+  SIG_KEY_NAME: "redhatrelease2"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-staging-openshifthosted.yaml
+++ b/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-staging-openshifthosted.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-openshifthosted"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
+++ b/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-redhatbeta2"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
+++ b/components/internal-services/internal-production/signing/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-redhatrelease2"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/components/internal-services/internal-production/signing/kustomization.yaml
+++ b/components/internal-services/internal-production/signing/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - hacbs-signing-pipeline-config-openshifthosted.yaml
+  - hacbs-signing-pipeline-config-redhatbeta2.yaml
+  - hacbs-signing-pipeline-config-redhatrelease2.yaml
+  - hacbs-signing-pipeline-config-staging-openshifthosted.yaml
+  - hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
+  - hacbs-signing-pipeline-config-staging-redhatrelease2.yaml


### PR DESCRIPTION
This commit adds signing configMaps, network policy, and the InternalServicesConfig for the internal-services prod deployment.