### PR TITLE
chore(KFLUXSPRT-5156): onboarding konflux-support-ops to HCP common clusters

### DIFF
--- a/argo-cd-apps/base/internal/konflux-support-ops/appset.yaml
+++ b/argo-cd-apps/base/internal/konflux-support-ops/appset.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-support-ops
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/konflux-support-ops
+          environment: ""
+          clusterName: ""
+  template:
+    metadata:
+      name: konflux-support-ops-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-support-ops
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/internal/konflux-support-ops/kustomization.yaml
+++ b/argo-cd-apps/base/internal/konflux-support-ops/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset.yaml

--- a/argo-cd-apps/base/internal/kustomization.yaml
+++ b/argo-cd-apps/base/internal/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - openshift-pipelines
   - kargo
   - cert-manager
+  - konflux-support-ops

--- a/components/konflux-support-ops/base/kustomization.yaml
+++ b/components/konflux-support-ops/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# - deployment.yaml
+# - service.yaml
+
+namespace: konflux-support-ops

--- a/components/konflux-support-ops/internal-production/kustomization.yaml
+++ b/components/konflux-support-ops/internal-production/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/components/konflux-support-ops/internal-staging/kustomization.yaml
+++ b/components/konflux-support-ops/internal-staging/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: konflux-support-ops
+
+resources:
+- ../base


### PR DESCRIPTION
onboarding konflux-support-ops to common clusters.
- Created a namespace `konflux-support-ops-ns`
