### PR TITLE
chore: use nested kustomization files internal-services

### DIFF
--- a/components/internal-services/base/crds/kustomization.yaml
+++ b/components/internal-services/base/crds/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - appstudio.redhat.com_internalrequests.yaml
+  - appstudio.redhat.com_internalservicesconfigs.yaml

--- a/components/internal-services/base/cronjob/kustomization.yaml
+++ b/components/internal-services/base/cronjob/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cleanup-internal-requests-pipelineruns.yaml

--- a/components/internal-services/base/eso/kustomization.yaml
+++ b/components/internal-services/base/eso/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - secret-store.yaml
+  - secret-id.yaml

--- a/components/internal-services/base/kustomization.yaml
+++ b/components/internal-services/base/kustomization.yaml
@@ -3,25 +3,10 @@ kind: Kustomization
 
 resources:
   # Custom Resource Definitions
-  - crds/appstudio.redhat.com_internalrequests.yaml
-  - crds/appstudio.redhat.com_internalservicesconfigs.yaml
+  - crds/
   # External Secrets Resources
-  - eso/secret-store.yaml
-  - eso/secret-id.yaml
+  - eso/
   # RBAC Resources
-  - rbac/service_account.yaml
-  - rbac/role.yaml
-  - rbac/role_binding.yaml
-  - rbac/leader_election_role.yaml
-  - rbac/leader_election_role_binding.yaml
-  - rbac/auth_proxy_client_clusterrole.yaml
-  - rbac/auth_proxy_role.yaml
-  - rbac/auth_proxy_role_binding.yaml
-  - rbac/auth_proxy_service.yaml
-  - rbac/internalrequest_editor_role.yaml
-  - rbac/internalrequest_viewer_role.yaml
-  - rbac/internalservicesconfig_editor_role.yaml
-  - rbac/internalservicesconfig_viewer_role.yaml
-
+  - rbac/
   # CronJob Resources
-  - cronjob/cleanup-internal-requests-pipelineruns.yaml
+  - cronjob/

--- a/components/internal-services/base/rbac/kustomization.yaml
+++ b/components/internal-services/base/rbac/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service_account.yaml
+  - role.yaml
+  - role_binding.yaml
+  - leader_election_role.yaml
+  - leader_election_role_binding.yaml
+  - auth_proxy_client_clusterrole.yaml
+  - auth_proxy_role.yaml
+  - auth_proxy_role_binding.yaml
+  - auth_proxy_service.yaml
+  - internalrequest_editor_role.yaml
+  - internalrequest_viewer_role.yaml
+  - internalservicesconfig_editor_role.yaml
+  - internalservicesconfig_viewer_role.yaml

--- a/components/internal-services/internal-staging/config/kustomization.yaml
+++ b/components/internal-services/internal-staging/config/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - internal-services-config.yaml

--- a/components/internal-services/internal-staging/kustomization.yaml
+++ b/components/internal-services/internal-staging/kustomization.yaml
@@ -6,22 +6,16 @@ resources:
   - ../base
 
   # Manager deployments for staging
-  - manager/manager-staging-p01.yaml
-  - manager/manager-staging-rh01.yaml
+  - manager/
 
   # Network Policy
-  - networkpolicy/network_policy.yaml
+  - networkpolicy/
 
-  # Configuration
-  - config/internal-services-config.yaml
+  # InternalServicesConfig
+  - config/
 
   # External Secrets
-  - es/es.yaml
+  - es/
 
   # Signing configurations
-  - signing/hacbs-signing-pipeline-config-openshifthosted.yaml
-  - signing/hacbs-signing-pipeline-config-redhatbeta2.yaml
-  - signing/hacbs-signing-pipeline-config-redhatrelease2.yaml
-  - signing/hacbs-signing-pipeline-config-staging-openshifthosted.yaml
-  - signing/hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
-  - signing/hacbs-signing-pipeline-config-staging-redhatrelease2.yaml
+  - signing/

--- a/components/internal-services/internal-staging/manager/kustomization.yaml
+++ b/components/internal-services/internal-staging/manager/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - manager-staging-p01.yaml
+  - manager-staging-rh01.yaml

--- a/components/internal-services/internal-staging/networkpolicy/kustomization.yaml
+++ b/components/internal-services/internal-staging/networkpolicy/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - network_policy.yaml

--- a/components/internal-services/internal-staging/signing/kustomization.yaml
+++ b/components/internal-services/internal-staging/signing/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - hacbs-signing-pipeline-config-openshifthosted.yaml
+  - hacbs-signing-pipeline-config-redhatbeta2.yaml
+  - hacbs-signing-pipeline-config-redhatrelease2.yaml
+  - hacbs-signing-pipeline-config-staging-openshifthosted.yaml
+  - hacbs-signing-pipeline-config-staging-redhatbeta2.yaml
+  - hacbs-signing-pipeline-config-staging-redhatrelease2.yaml


### PR DESCRIPTION
This commit updates the internal-services directory to use nested kustomization files instead of pointing directly at each yaml file. This is a little less error prone, as if you add a new file to a directory, you don't have to worry about also updating the kustomization.yaml file.