### PR TITLE
feat(RELEASE-1863): add stone-prod-p01 internal-services prod manager

### DIFF
--- a/components/internal-services/internal-production/kustomization.yaml
+++ b/components/internal-services/internal-production/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - es/
   # InternalServicesConfig
   - config/
+  # Manager deployments
+  - manager/
   # NetworkPolicy
   - networkpolicy/
   # Signing ConfigMaps

--- a/components/internal-services/internal-production/manager/kustomization.yaml
+++ b/components/internal-services/internal-production/manager/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - manager-stone-prod-p01.yaml

--- a/components/internal-services/internal-production/manager/manager-stone-prod-p01.yaml
+++ b/components/internal-services/internal-production/manager/manager-stone-prod-p01.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager-prod-p01
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager-prod-p01
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: internal-services
+    app.kubernetes.io/part-of: internal-services
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
+      securityContext:
+        runAsNonRoot: true
+        # TODO(user): For common cases that do not require escalating privileges
+        # it is recommended to ensure that all your Pods/Containers are restrictive.
+        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
+        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
+        # seccompProfile:
+        #   type: RuntimeDefault
+      containers:
+        - command:
+            - /manager
+          args:
+            - --leader-elect
+            - --remote-cluster-config-file
+            - /mnt/internal-services/remote-client-config/kubeconfig
+            - --leader-election-id
+            - "prod-p01"
+          image: quay.io/konflux-ci/internal-services:4ea5fdeacbe7072c7f992341cba04bed779269e6
+          name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # TODO(user): Configure the resources accordingly based on the project requirements.
+          # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          env:
+            - name: SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /mnt/internal-services/remote-client-config
+              name: remote-client-config
+              readOnly: true
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: remote-client-config
+          secret:
+            secretName: remote-client-config-prod-p01


### PR DESCRIPTION
This commit adds the stone-prod-p01 manager file for internal-services in production. This cluster will be used first to verify things. If things go well, the other production manager files will be added in a followup commit.