### PR TITLE
chore(RELEASE-1863): temporarily add managed-release-team-tenant

### DIFF
--- a/components/internal-services/internal-production/config/internal-services-config.yaml
+++ b/components/internal-services/internal-production/config/internal-services-config.yaml
@@ -4,6 +4,7 @@ metadata:
   name: config
 spec:
   allowList:
+  - managed-release-team-tenant
   - rhtap-releng-tenant
   - rh-managed-cnv-fbc-tenant
   - rh-managed-red-hat-acm-tenant


### PR DESCRIPTION
Temporarily add the managed-release-team-tenant namespace to the allowList of the internalServicesConfig for the production instances of internal-services, as this namespace will be used to validate the deployment. Once validation is complete, this commit will be reversed.