### PR TITLE
chore(RELEASE-1863): use jbieren ns instead of managed release team

### DIFF
--- a/components/internal-services/internal-production/config/internal-services-config.yaml
+++ b/components/internal-services/internal-production/config/internal-services-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: config
 spec:
   allowList:
-  - managed-release-team-tenant
+  - jbieren-tenant
   - rhtap-releng-tenant
   - rh-managed-cnv-fbc-tenant
   - rh-managed-red-hat-acm-tenant


### PR DESCRIPTION
This commit changes the temporary allowed namespace in the internal-services prod InternalServicesConfig from managed-release-team-tenant to jbieren-tenant. This is because I don't have the permissions I need in managed-release-team-tenant, so I am using jbieren-tenant as my managed ns for testing.