### PR TITLE
chore(RELEASE-1863): remove jbieren-tenant from allowList

### DIFF
--- a/components/internal-services/internal-production/config/internal-services-config.yaml
+++ b/components/internal-services/internal-production/config/internal-services-config.yaml
@@ -4,7 +4,6 @@ metadata:
   name: config
 spec:
   allowList:
-  - jbieren-tenant
   - rhtap-releng-tenant
   - rh-managed-cnv-fbc-tenant
   - rh-managed-red-hat-acm-tenant


### PR DESCRIPTION
Testing in production is complete; this commit removes jbieren-tenant from the allowList in the production internal-services InternalServicesConfig.