### PR TITLE
chore(RELEASE-1880: add release-service-bot to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /components/iam/ @gbenhaim @hugares @enkeefe00 @oswcab
 
 # Owners for internal-services
-/components/internal-services/ @davidmogar @johnbieren @scoheb @theflockers @mmalina @happybhati @seanconroy2021 @jinqi7 @filipnikolovski @elenagerman
+/components/internal-services/ @davidmogar @johnbieren @scoheb @theflockers @mmalina @happybhati @seanconroy2021 @jinqi7 @filipnikolovski @elenagerman @release-service-bot
 
 # Owners for kargo
 /components/kargo/ @gbenhaim @hugares @enkeefe00


### PR DESCRIPTION
This commit adds the release-service-bot to the CODEOWNERS file for internal-services.