### PR TITLE
Change internal-services-manager-role to namespace level

### DIFF
--- a/components/internal-services/base/rbac/role.yaml
+++ b/components/internal-services/base/rbac/role.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: internal-services-manager-role
 rules:

--- a/components/internal-services/base/rbac/role_binding.yaml
+++ b/components/internal-services/base/rbac/role_binding.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: clusterrolebinding
@@ -11,7 +11,7 @@ metadata:
   name: internal-services-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: internal-services-manager-role
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
Replace the ClusterRole by a Role and ClusterRoleBinding by a RoleBinding as this is only required in the internal-services namespace. Doing it at the cluster level was granting unnecessary permission to the other namespaces on common clusters.