### PR TITLE
 KFLUXINFRA-3014: Deploy TektonConfig w/ ArgoCD on kflux-c-stg-i01

### DIFF
--- a/components/openshift-pipelines/internal-staging/kustomization.yaml
+++ b/components/openshift-pipelines/internal-staging/kustomization.yaml
@@ -4,9 +4,5 @@ kind: Kustomization
 resources:
   # Base resources
   - ../base
-
-patches:
-  - path: tekton-config-patch.yaml
-    target:
-      kind: TektonConfig
-      name: config
+  # Disable Tekton Results by letting ArgoCD deploy the TektonConfig
+  - tekton-config.yaml

--- a/components/openshift-pipelines/internal-staging/tekton-config-patch.yaml
+++ b/components/openshift-pipelines/internal-staging/tekton-config-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonConfig
-metadata:
-  name: config
-spec:
-  result:
-    disabled: true

--- a/components/openshift-pipelines/internal-staging/tekton-config.yaml
+++ b/components/openshift-pipelines/internal-staging/tekton-config.yaml
@@ -1,0 +1,145 @@
+# Adding this TektonConfig resource allows ArgoCD to control the TektonConfig deployment in contrast
+# to letting the openshift-pipelines operator control it. This way, Tekton Results can be disabled.
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  finalizers:
+    - tektonconfigs.operator.tekton.dev
+  labels:
+    openshift-pipelines.tekton.dev/sa-created: 'true'
+    operator.tekton.dev/release-version: 1.21.0
+  name: config
+spec:
+  addon:
+    params:
+      - name: resolverStepActions
+        value: 'true'
+      - name: communityResolverTasks
+        value: 'true'
+      - name: pipelineTemplates
+        value: 'true'
+      - name: resolverTasks
+        value: 'true'
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        enable: true
+        options: {}
+        settings:
+          bitbucket-cloud-additional-source-ip: ''
+          auto-configure-repo-namespace-template: ''
+          tekton-dashboard-url: ''
+          custom-console-url-pr-tasklog: ''
+          bitbucket-cloud-check-source-ip: 'true'
+          hub-catalog-type: artifacthub
+          enable-cancel-in-progress-on-push: 'false'
+          custom-console-url-pr-details: ''
+          auto-configure-repo-repository-template: ''
+          remote-tasks: 'true'
+          application-name: Pipelines as Code CI
+          auto-configure-new-github-repo: 'false'
+          custom-console-url-namespace: ''
+          skip-push-event-for-pr-commits: 'true'
+          max-keep-run-upper-limit: '0'
+          error-log-snippet-number-of-lines: '3'
+          error-log-snippet: 'true'
+          error-detection-from-container-logs: 'true'
+          secret-github-app-scope-extra-repos: ''
+          remember-ok-to-test: 'false'
+          hub-url: 'https://artifacthub.io'
+          error-detection-max-number-of-lines: '50'
+          error-detection-simple-regexp: '^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+)?([ ]*)?(?P<error>.*)'
+          require-ok-to-test-sha: 'false'
+          default-max-keep-runs: '0'
+          custom-console-name: ''
+          secret-auto-create: 'true'
+          custom-console-url: ''
+          secret-github-app-token-scoped: 'true'
+          enable-cancel-in-progress-on-pull-requests: 'false'
+      scc:
+        default: pipelines-scc
+  tektonpruner:
+    disabled: true
+    global-config:
+      enforcedConfigLevel: global
+      historyLimit: 100
+    options: {}
+  chain:
+    artifacts.taskrun.storage: oci
+    artifacts.pipelinerun.storage: oci
+    artifacts.pipelinerun.format: in-toto
+    artifacts.taskrun.format: in-toto
+    performance:
+      disable-ha: false
+    artifacts.oci.storage: oci
+    disabled: false
+    artifacts.oci.format: simplesigning
+    options: {}
+  pipeline:
+    running-in-environment-with-injected-sidecars: true
+    metrics.taskrun.duration-type: histogram
+    results-from: termination-message
+    enforce-nonfalsifiability: none
+    enable-cluster-resolver: true
+    metrics.pipelinerun.duration-type: histogram
+    await-sidecar-readiness: true
+    coschedule: workspaces
+    metrics.count.enable-reason: false
+    params:
+      - name: enableMetrics
+        value: 'true'
+    enable-step-actions: true
+    max-result-size: 4096
+    enable-hub-resolver: true
+    default-service-account: pipeline
+    enable-param-enum: false
+    enable-git-resolver: true
+    enable-bundles-resolver: true
+    require-git-ssh-secret-known-hosts: false
+    set-security-context: false
+    enable-cel-in-whenexpression: false
+    performance:
+      disable-ha: false
+    send-cloudevents-for-runs: false
+    metrics.taskrun.level: task
+    trusted-resources-verification-no-match-policy: ignore
+    metrics.pipelinerun.level: pipeline
+    enable-api-fields: alpha
+    keep-pod-on-cancel: 'false'
+    enable-provenance-in-status: true
+    enable-custom-tasks: 'true'
+    disable-creds-init: 'false'
+    options: {}
+    disable-affinity-assistant: 'true'
+    enable-kubernetes-sidecar: 'false'
+    disable-inline-spec: ''
+    enable-concise-resolver-syntax: 'false'
+    enable-tekton-oci-bundles: 'false'
+    enable-artifacts: 'false'
+  config: {}
+  pruner:
+    disabled: false
+    keep: 100
+    resources:
+      - pipelinerun
+    schedule: 0 8 * * *
+  profile: all
+  targetNamespace: openshift-pipelines
+  dashboard:
+    options: {}
+    readonly: false
+  hub:
+    options: {}
+  trigger:
+    default-service-account: pipeline
+    disabled: false
+    enable-api-fields: stable
+    options: {}
+  result:
+    disabled: true
+    is_external_db: false
+    options: {}
+    performance:
+      disable-ha: false
+    route_enabled: true
+    route_tls_termination: edge


### PR DESCRIPTION
Since previous attempts to disable Tekton Results failed (see https://github.com/redhat-appstudio/infra-common-deployments/pull/269 and https://github.com/redhat-appstudio/infra-common-deployments/pull/254) , deploy a disabled Tekton Results `TektonConfig` to allow ArgoCD to manage the resource instead of the openshift-pipelines operator.

Assisted-by: Gemini

[KFLUXINFRA-3014](https://issues.redhat.com/browse/KFLUXINFRA-3014)

[KFLUXINFRA-3014]: https://redhat.atlassian.net/browse/KFLUXINFRA-3014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ