### PR TITLE
Modify OWNERS file to update approvers and reviewers

### DIFF
--- a/components/konflux-support-ops/OWNERS
+++ b/components/konflux-support-ops/OWNERS
@@ -1,13 +1,16 @@
 # See the OWNERS docs: https://go.k8s.io/owners
 
 approvers:
-- Omeramsc
-- Kousalya1998
-- svatares
-- hguemar
-- shacharFridman
+- npotluri-rh
+- hareldev
+- shay6
+- max0n1x
 
 reviewers:
+- npotluri-rh
+- hareldev
+- shay6
+- max0n1x
 - Omeramsc
 - Kousalya1998
 - svatares


### PR DESCRIPTION
Updated approvers and reviewers in OWNERS file.
Maintenance of the support-ops tool transitioned to team members of rover group dno-integration-dev