### PR TITLE
KFLUXINFRA-3597: Create the rover-group-sync component

### DIFF
--- a/argo-cd-apps/base/internal/kustomization.yaml
+++ b/argo-cd-apps/base/internal/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - codecov
   - konflux-devlake
   - policies
+  - rover-group-sync

--- a/argo-cd-apps/base/internal/rover-group-sync/appset.yaml
+++ b/argo-cd-apps/base/internal/rover-group-sync/appset.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: rover-group-sync
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/rover-group-sync
+          environment: ""
+  template:
+    metadata:
+      name: rover-group-sync
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+      destination:
+        namespace: rover-group-sync
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/internal/rover-group-sync/kustomization.yaml
+++ b/argo-cd-apps/base/internal/rover-group-sync/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset.yaml

--- a/components/rover-group-sync/OWNERS
+++ b/components/rover-group-sync/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+  - hugares
+  - enkeefe00
+  - sadlerap
+  - filariow
+  - mshaposhnik
+  - manish-jangra
+
+reviewers:
+  - hugares
+  - enkeefe00
+  - sadlerap
+  - filariow
+  - mshaposhnik
+  - manish-jangra

--- a/components/rover-group-sync/README.md
+++ b/components/rover-group-sync/README.md
@@ -1,0 +1,55 @@
+# Rover Group Sync
+
+The Rover Group Sync component consists of a scheduled job that ensures `Group` YAML manifest files in a `groups/<environment>/` directory of a Git repository are kept up to date with Konflux's [Rover][rover] LDAP groups. The component runs `oc adm groups sync` (LDAP only), then commits and pushes to the configured branch and Git repository when there are changes to the groups.
+
+The container image and entrypoint script are maintained in the [infrastructure](https://github.com/redhat-appstudio/infrastructure) repository under `maintenance/rover-group-sync`.
+
+[rover]: https://rover.redhat.com/
+
+## Layout
+
+`Secret`s spawned from `ExternalSecret`s in the `external-secrets/` directory are mounted into a `CronJob` along with a `ConfigMap` generated using the file(s) in the `config/` directory. The `CronJob` runs in the associated `Namspace` using the associated `ServiceAccount`.
+
+## Default Behavior
+
+**Schedule:** daily at 02:00 (cluster controller time; typically UTC).
+**Concurrency:** `Forbid` (no overlapping runs).
+**Volume Mounts:** named to satisfy the expected default environment variable paths
+**Environment:** defaults to a staging environment with `ENVIRONMENT` being set to 'staging'
+
+## Secrets and Configurations (Vault)
+
+External Secrets sync from Vault (via `appsre-stonesoup-vault`) into Kubernetes `Secret`s. Paths are under `staging/infrastructure/group-sync/`. Currently, all Vault secrets that need to be mounted have keys and mount paths that line up with the expected default environment variable paths in the script (see [Environment Variables](#environment-variables) below). If a Secret's keys change, the new value **must** be passed in via the appropriate env variable.
+
+The LDAP sync config template in `base/config/ldap-sync-config.yaml` has placeholders to prevent secret credentials from being committed to the repository; the script injects the bind DN, password, and CA path at runtime using environment variables ties to Kubernetes `Secret`s.
+
+| Resource Name | Resource Type | Typical Use | Expected Keys|
+|---------------|---------------|-------------|--------------|
+| `ldap-creds` | `Secret` | LDAP bind credentials | none |
+| `git-repo-creds` | `Secret` | Credentials for the Git repo | `ssh_public` and `ssh_private` keys|
+| `mtls-ca-validators` | `Secret` | Permissions for LDAP TLS | `ca.crt` |
+| `rover-group-sync-config` | `ConfigMap` | Template LDAP config for `oc adm groups sync` | ldap-sync-config.yaml |
+
+## Environment Variables
+
+| env Name | Purpose | Required | Default Value | Source |
+|----------|---------|----------|---------------|--------|
+| `SYNC_CONFIG_SOURCE` | Path to LDAP config template | No | `config/ldap-sync-config.yaml` | `rover-group-sync` ConfigMap |
+| `LDAP_CA_PATH` | Path to LDAP CA certificate | No | `secrets/ca.crt` | `ldap-creds` Secret |
+| `GIT_PRIVATE_SSH_PATH` | Path to Git repo's private SSH key | No | `secrets/git-repo/ssh_private` | `git-repo-creds` Secret |
+| `LDAP_DN` | LDAP credential injection value | Yes | N/A | `ldap-creds` Secret |
+| `LDAP_PASSWORD` | LDAP credential injection value | Yes | N/A | `ldap-creds` Secret |
+| `GIT_REPO_URL` | Git repository URL | Yes | N/A | `git-creds` Secret |
+| `GIT_SSH_PUBLIC_KEY` | Git repository public SSH key | Yes | N/A | `git-creds` Secret |
+| `GIT_BRANCH` | Git repository branch | No | "main" | CronJob env |
+| `ENVIRONMENT` | The type of environment hosting the component | No | "staging" | Cronjob env |
+
+## Local checks
+
+Run a one-off job on the cluster (same pod template as the CronJob):
+
+```bash
+oc create job "rover-group-sync-manual-$(date +%s)" \
+  --from=cronjob/rover-group-sync \
+  -n rover-group-sync
+```

--- a/components/rover-group-sync/base/config/ldap-sync-config.yaml
+++ b/components/rover-group-sync/base/config/ldap-sync-config.yaml
@@ -1,0 +1,38 @@
+# OpenShift LDAP sync config for: oc adm groups sync --sync-config=...
+# Mirrors components/authentication/base/group-sync/konflux-rover-groups.yaml (RFC2307).
+#
+# Replace:
+#  - url: use IT-approved internal LDAP (ldapfrac was decommissioned for external use)
+#  - bindDN / bindPassword: from the same material as konflux-ldap-sa (Vault path in ExternalSecret)
+#  - ca: path to PEM bundle that validates the LDAP server cert (same trust as mtls-ca-validators)
+#
+# Do not commit real credentials; inject at runtime (CronJob volume from Secret).
+
+kind: LDAPSyncConfig
+apiVersion: v1
+url: ldaps://ldap.corp.redhat.com
+bindDN: "REPLACE_WITH_BIND_DN"
+bindPassword: "REPLACE_WITH_BIND_PASSWORD"
+insecure: false
+ca: "REPLACE_WITH_CA_PATH"
+
+rfc2307:
+  groupsQuery:
+    baseDN: "ou=adhoc,ou=managedGroups,dc=redhat,dc=com"
+    derefAliases: never
+    scope: sub
+    filter: (&(objectClass=rhatRoverGroup)(|(cn=konflux-*)(cn=ai-konflux-user-support)(cn=plm-poe)))
+  groupUIDAttribute: dn
+  groupNameAttributes:
+    - cn
+  groupMembershipAttributes:
+    - uniqueMember
+  usersQuery:
+    baseDN: "dc=redhat,dc=com"
+    derefAliases: never
+    scope: sub
+  userNameAttributes:
+    - uid
+  userUIDAttribute: dn
+  tolerateMemberNotFoundErrors: true
+  tolerateMemberOutOfScopeErrors: true

--- a/components/rover-group-sync/base/cronjob.yaml
+++ b/components/rover-group-sync/base/cronjob.yaml
@@ -1,0 +1,84 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rover-group-sync
+  namespace: rover-group-sync
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 7
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: rover-group-sync-sa
+          # Allow non-root (UID 1000) to read mounted Secrets (e.g. SSH key) via group permissions.
+          securityContext:
+            fsGroup: 1000
+          volumes:
+            - name: rover-group-sync-config
+              configMap:
+                name: rover-group-sync-config
+                defaultMode: 420
+            - name: ca
+              secret:
+                secretName: mtls-ca-validators
+            - name: git-repo-creds
+              secret:
+                secretName: git-repo-creds
+                defaultMode: 0640
+            - name: tmp
+              emptyDir: {}
+          containers:
+            - name: rover-group-sync
+              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:29815287f5171aed119daeec7a9f5a6785270f5acab42e1adcade0c2e23d14d1
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/bash", "/scripts/sync-rover-groups.sh"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+                - name: GIT_REPO_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: git-repo-creds
+                      key: url
+                - name: LDAP_DN
+                  valueFrom:
+                    secretKeyRef:
+                      name: ldap-creds
+                      key: username
+                - name: LDAP_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ldap-creds
+                      key: password
+                - name: GIT_SSH_PUBLIC_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: git-repo-creds
+                      key: ssh_public
+              volumeMounts:
+                - name: rover-group-sync-config
+                  mountPath: /config
+                  readOnly: true
+                - name: ca
+                  mountPath: /secrets
+                  readOnly: true
+                - name: git-repo-creds
+                  mountPath: /secrets/git-repo
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  memory: 512Mi

--- a/components/rover-group-sync/base/external-secrets/ca.yaml
+++ b/components/rover-group-sync/base/external-secrets/ca.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mtls-ca-validators
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/infrastructure/group-sync/mtls-ca-validators
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: mtls-ca-validators

--- a/components/rover-group-sync/base/external-secrets/git-repo-creds.yaml
+++ b/components/rover-group-sync/base/external-secrets/git-repo-creds.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: git-repo-creds
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/infrastructure/group-sync/git-repo-ssh-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: git-repo-creds

--- a/components/rover-group-sync/base/external-secrets/kustomization.yaml
+++ b/components/rover-group-sync/base/external-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ldap-creds.yaml
+  - git-repo-creds.yaml
+  - ca.yaml

--- a/components/rover-group-sync/base/external-secrets/ldap-creds.yaml
+++ b/components/rover-group-sync/base/external-secrets/ldap-creds.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ldap-creds
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/infrastructure/group-sync/konflux-ldap-sa
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ldap-creds

--- a/components/rover-group-sync/base/kustomization.yaml
+++ b/components/rover-group-sync/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rover-group-sync
+resources:
+  - external-secrets
+  - cronjob.yaml
+  - namespace.yaml
+  - serviceaccount.yaml
+configMapGenerator:
+  - name: rover-group-sync-config
+    files:
+      - ldap-sync-config.yaml=./config/ldap-sync-config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/rover-group-sync/base/namespace.yaml
+++ b/components/rover-group-sync/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rover-group-sync

--- a/components/rover-group-sync/base/serviceaccount.yaml
+++ b/components/rover-group-sync/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rover-group-sync-sa

--- a/components/rover-group-sync/internal-staging/kustomization.yaml
+++ b/components/rover-group-sync/internal-staging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rover-group-sync
+resources:
+  - ../base


### PR DESCRIPTION
## What
Adds a new component  that syncs Konflux Rover groups from the internal Red Hat LDAP server into the internal infrastructure Git repository’s groups/ directory.

## Why
This will automate keeping Rover group definitions in a Git repository to keep the repo as "the source of truth" and keep group membership in step with LDAP.

## Validation
Ran the `sync-rover-groups.sh` locally against the common internal production cluster (kflux-c-prd-i01) using credentials scoped to a personal test repository. All expected Group manifests were produced and were valid.

```
bash config/sync-rover-groups.sh 
Cloning into '/tmp/git-work'...
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (3/3), done.
Retrieving groups from LDAP...
Creating Group manifests in target directory...
Global rh-pre-commit.....................................................Passed
[main 815f364] chore(groups): sync rover LDAP groups main 2026-04-16T16:11:54Z
 51 files changed, 6468 insertions(+)
 create mode 100644 groups/ai-konflux-user-support.yaml
 create mode 100644 groups/konflux-admins.yaml
 create mode 100644 groups/konflux-build-admins.yaml
 create mode 100644 groups/konflux-build.yaml
 create mode 100644 groups/konflux-centos-stream-rhel-containers-owners.yaml
 create mode 100644 groups/konflux-ci-maintainers.yaml
 create mode 100644 groups/konflux-community-production-secrets.yaml
 create mode 100644 groups/konflux-community-stage-secrets.yaml
 create mode 100644 groups/konflux-contributors.yaml
 create mode 100644 groups/konflux-cost-management-admins.yaml
 create mode 100644 groups/konflux-cost-management-users.yaml
 create mode 100644 groups/konflux-devprod.yaml
 create mode 100644 groups/konflux-ec.yaml
 create mode 100644 groups/konflux-fullsend-admins.yaml
 create mode 100644 groups/konflux-gitops-admins.yaml
 create mode 100644 groups/konflux-gitops.yaml
 create mode 100644 groups/konflux-grafana-viewers.yaml
 create mode 100644 groups/konflux-hummingbird-admin-access.yaml
 create mode 100644 groups/konflux-infra.yaml
 create mode 100644 groups/konflux-integration.yaml
 create mode 100644 groups/konflux-kubearchive.yaml
 create mode 100644 groups/konflux-kueue-workloads.yaml
 create mode 100644 groups/konflux-migration-notifications.yaml
 create mode 100644 groups/konflux-migration.yaml
 create mode 100644 groups/konflux-mintmaker-team.yaml
 create mode 100644 groups/konflux-o11y-admins.yaml
 create mode 100644 groups/konflux-o11y.yaml
 create mode 100644 groups/konflux-performance.yaml
 create mode 100644 groups/konflux-perfscale-grafanacorp-admins.yaml
 create mode 100644 groups/konflux-perfscale-grafanacorp-users.yaml
 create mode 100644 groups/konflux-pipeline-service-admins.yaml
 create mode 100644 groups/konflux-pipeline-service.yaml
 create mode 100644 groups/konflux-policy-governance.yaml
 create mode 100644 groups/konflux-pool-admins.yaml
 create mode 100644 groups/konflux-portal.yaml
 create mode 100644 groups/konflux-prodsec-support.yaml
 create mode 100644 groups/konflux-qe-admins.yaml
 create mode 100644 groups/konflux-qe.yaml
 create mode 100644 groups/konflux-release-team.yaml
 create mode 100644 groups/konflux-splunk-apps-admins.yaml
 create mode 100644 groups/konflux-sre.yaml
 create mode 100644 groups/konflux-support-ops-collab.yaml
 create mode 100644 groups/konflux-support-ops-source-api.yaml
 create mode 100644 groups/konflux-support-ops.yaml
 create mode 100644 groups/konflux-support.yaml
 create mode 100644 groups/konflux-tenant-ops.yaml
 create mode 100644 groups/konflux-ui-qe.yaml
 create mode 100644 groups/konflux-ui.yaml
 create mode 100644 groups/konflux-vanguard.yaml
 create mode 100644 groups/konflux-workspace-admins.yaml
 create mode 100644 groups/plm-poe.yaml
Enumerating objects: 55, done.
Counting objects: 100% (55/55), done.
Delta compression using up to 12 threads
Compressing objects: 100% (54/54), done.
Writing objects: 100% (54/54), 35.66 KiB | 7.13 MiB/s, done.
Total 54 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), done.
To github.com:enkeefe00/cursor-projects.git
   48b18dc..815f364  main -> main
```

## Risk Assessment
Risk Level: Medium
Rollback: Revert this change (or stop wiring/deploying the rover-group-sync component) so the CronJob is not scheduled; remove or rotate any secrets if they were applied in a shared environment. If the job has already run, confirm whether a one-off Git revert of generated commits is needed in the target repo.
Notes: New scheduled workload with LDAP and Git write access. Blast radius is mainly incorrect or stale group data in the target repo and load on LDAP/Git if the job misbehaves; secret handling and RBAC scope should stay minimal and reviewed in review.

Generated-by: Cursor