### PR TITLE
KFLUXINFRA-3603: align Splunk logging ExternalSecret Vault paths

### DIFF
--- a/components/monitoring/logging/base/external-secrets/splunk-log-forwarder-external-secrets.yaml
+++ b/components/monitoring/logging/base/external-secrets/splunk-log-forwarder-external-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: log-forwarder-splunk-rhtap-application-external-secret
@@ -17,7 +17,7 @@ spec:
     name: log-forwarder-splunk-rhtap-application-secret
     deletionPolicy: Delete
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: log-forwarder-splunk-rhtap-audit-external-secret

--- a/components/monitoring/logging/external-production/kustomization.yaml
+++ b/components/monitoring/logging/external-production/kustomization.yaml
@@ -7,22 +7,22 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: production/monitoring/logging/fluentd/splunk-forwarder-rhtap-production-application
+        value: production/monitoring/logging/splunk/rh_rhtap_production_app
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: production/monitoring/logging/fluentd/splunk-forwarder-rhtap-production-audit
+        value: production/monitoring/logging/splunk/rh_rhtap_production_audit
   - path: patches/configure-logforwarder-compression-patch.yaml
     target:
       group: observability.openshift.io

--- a/components/monitoring/logging/external-staging/kustomization.yaml
+++ b/components/monitoring/logging/external-staging/kustomization.yaml
@@ -7,22 +7,22 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: staging/monitoring/logging/fluentd/splunk-forwarder-rhtap-staging-application
+        value: staging/monitoring/logging/splunk/rh_rhtap_stage_app
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: staging/monitoring/logging/fluentd/splunk-forwarder-rhtap-staging-audit
+        value: staging/monitoring/logging/splunk/rh_rhtap_stage_audit
   - path: patches/configure-logforwarder-compression-patch.yaml
     target:
       group: observability.openshift.io

--- a/components/monitoring/logging/internal-production/kustomization.yaml
+++ b/components/monitoring/logging/internal-production/kustomization.yaml
@@ -7,22 +7,22 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: production/monitoring/logging/fluentd/splunk-forwarder-rhtap-production-application
+        value: production/monitoring/logging/splunk/rh_rhtap_production_app
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: production/monitoring/logging/fluentd/splunk-forwarder-rhtap-production-audit
+        value: production/monitoring/logging/splunk/rh_rhtap_production_audit
   - path: patches/configure-logforwarder-compression-patch.yaml
     target:
       group: observability.openshift.io

--- a/components/monitoring/logging/internal-staging/kustomization.yaml
+++ b/components/monitoring/logging/internal-staging/kustomization.yaml
@@ -7,22 +7,22 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: staging/monitoring/logging/fluentd/splunk-forwarder-rhtap-staging-application
+        value: staging/monitoring/logging/splunk/rh_rhtap_stage_app
   - target:
       group: external-secrets.io
-      version: v1beta1
+      version: v1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |
       - op: replace
         path: /spec/dataFrom/0/extract/key
-        value: staging/monitoring/logging/fluentd/splunk-forwarder-rhtap-staging-audit
+        value: staging/monitoring/logging/splunk/rh_rhtap_stage_audit
   - path: patches/configure-logforwarder-compression-patch.yaml
     target:
       group: observability.openshift.io


### PR DESCRIPTION
## Summary

- Update ExternalSecret API version from `v1beta1` to `v1` in base and all overlays
- Migrate Vault paths from deprecated `fluentd/` prefix to current `splunk/` prefix for both staging and production (application + audit)
- Aligns infra-common-deployments with the paths already active in [infra-deployments](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/monitoring/logging)

### Vault path changes

| Environment | Type | Old | New |
|---|---|---|---|
| Staging | app | `staging/monitoring/logging/fluentd/splunk-forwarder-rhtap-staging-application` | `staging/monitoring/logging/splunk/rh_rhtap_stage_app` |
| Staging | audit | `staging/monitoring/logging/fluentd/splunk-forwarder-rhtap-staging-audit` | `staging/monitoring/logging/splunk/rh_rhtap_stage_audit` |
| Production | app | `production/monitoring/logging/fluentd/splunk-forwarder-rhtap-production-application` | `production/monitoring/logging/splunk/rh_rhtap_production_app` |
| Production | audit | `production/monitoring/logging/fluentd/splunk-forwarder-rhtap-production-audit` | `production/monitoring/logging/splunk/rh_rhtap_production_audit` |

## Test plan

- [x] Verified the 3 infra-deployments staging clusters (`stone-stg-rh01`, `stone-stage-p01`, `kflux-stg-es01`) already resolve to the correct HEC token via the new Vault paths
- [x] Confirmed `kflux-c-stg-e01` (managed by this repo) currently resolves to a different token due to the old `fluentd/` path
- [ ] After merge, verify `kflux-c-stg-e01` ExternalSecret refreshes and the `hecToken` matches the other staging clusters