### PR TITLE
KFLUXINFRA-3597: Add rover-group-sync namespace to AppSRE ClusterSecretStore

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -33,3 +33,4 @@ spec:
         - konflux-devlake
         - openshift-logging
         - konflux-support-ops
+        - rover-group-sync


### PR DESCRIPTION
This allows the Rover Group Sync component to pull secrets from Vault.