### PR TITLE
KFLUXINFRA-3597: Update Rover Group Sync CronJob image

### DIFF
--- a/components/rover-group-sync/base/cronjob.yaml
+++ b/components/rover-group-sync/base/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               emptyDir: {}
           containers:
             - name: rover-group-sync
-              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:29815287f5171aed119daeec7a9f5a6785270f5acab42e1adcade0c2e23d14d1
+              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:e0ae3f5eb75fbc26f55a2a8d0aec956da3da419034340ac730f518dfb470d5d7
               imagePullPolicy: IfNotPresent
               command: ["/bin/bash", "/scripts/sync-rover-groups.sh"]
               securityContext:


### PR DESCRIPTION
Use the new image that has git installed.