### PR TITLE
KFLUXINFRA-3597:  Update Rover Group Sync

### DIFF
--- a/components/rover-group-sync/README.md
+++ b/components/rover-group-sync/README.md
@@ -26,7 +26,7 @@ The LDAP sync config template in `base/config/ldap-sync-config.yaml` has placeho
 | Resource Name | Resource Type | Typical Use | Expected Keys|
 |---------------|---------------|-------------|--------------|
 | `ldap-creds` | `Secret` | LDAP bind credentials | none |
-| `git-repo-creds` | `Secret` | Credentials for the Git repo | `ssh_public` and `ssh_private` keys|
+| `git-repo-creds` | `Secret` | Credentials for the Git repo | `url` and `ssh_private` keys|
 | `mtls-ca-validators` | `Secret` | Permissions for LDAP TLS | `ca.crt` |
 | `rover-group-sync-config` | `ConfigMap` | Template LDAP config for `oc adm groups sync` | ldap-sync-config.yaml |
 
@@ -39,8 +39,7 @@ The LDAP sync config template in `base/config/ldap-sync-config.yaml` has placeho
 | `GIT_PRIVATE_SSH_PATH` | Path to Git repo's private SSH key | No | `secrets/git-repo/ssh_private` | `git-repo-creds` Secret |
 | `LDAP_DN` | LDAP credential injection value | Yes | N/A | `ldap-creds` Secret |
 | `LDAP_PASSWORD` | LDAP credential injection value | Yes | N/A | `ldap-creds` Secret |
-| `GIT_REPO_URL` | Git repository URL | Yes | N/A | `git-creds` Secret |
-| `GIT_SSH_PUBLIC_KEY` | Git repository public SSH key | Yes | N/A | `git-creds` Secret |
+| `GIT_REPO_URL` | Git repository URL | Yes | N/A | `git-repo-creds` Secret |
 | `GIT_BRANCH` | Git repository branch | No | "main" | CronJob env |
 | `ENVIRONMENT` | The type of environment hosting the component | No | "staging" | Cronjob env |
 

--- a/components/rover-group-sync/base/cronjob.yaml
+++ b/components/rover-group-sync/base/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               emptyDir: {}
           containers:
             - name: rover-group-sync
-              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:e0ae3f5eb75fbc26f55a2a8d0aec956da3da419034340ac730f518dfb470d5d7
+              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:706e398edf9489e3027cced5c21987f88869fdf4bc1bac5e35c428279d324083
               imagePullPolicy: IfNotPresent
               command: ["/bin/bash", "/scripts/sync-rover-groups.sh"]
               securityContext:
@@ -57,11 +57,6 @@ spec:
                     secretKeyRef:
                       name: ldap-creds
                       key: password
-                - name: GIT_SSH_PUBLIC_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: git-repo-creds
-                      key: ssh_public
               volumeMounts:
                 - name: rover-group-sync-config
                   mountPath: /config


### PR DESCRIPTION
Includes: https://github.com/redhat-appstudio/infrastructure/pull/121

Removes the need for the GIT_SSH_PUBLIC_KEY environment variable due to no longer building a custom known_hosts file.