### PR TITLE
Kargo permissions for the devprod team

### DIFF
--- a/components/kargo/OWNERS
+++ b/components/kargo/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+
+- psturc
+- p8r-the-gr8
+- flacatus

--- a/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
+++ b/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
@@ -26,6 +26,7 @@ valuesInline:
           - cluster-admins
           - dedicated-admins
           - konflux-infra
+          - konflux-devprod
       dex:
         enabled: true
         skipApprovalScreen: true

--- a/components/kargo/internal-staging/deployment/kustomization.yaml
+++ b/components/kargo/internal-staging/deployment/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - route-and-oauth.yaml
+  - rbac
 
 namespace: kargo
 

--- a/components/kargo/internal-staging/deployment/rbac/konflux-devprod-admins.yaml
+++ b/components/kargo/internal-staging/deployment/rbac/konflux-devprod-admins.yaml
@@ -1,0 +1,49 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-admins
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+  - apiGroups:
+    - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: konflux-devprod-admins

--- a/components/kargo/internal-staging/deployment/rbac/kustomization.yaml
+++ b/components/kargo/internal-staging/deployment/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- konflux-devprod-admins.yaml

--- a/components/kargo/internal-staging/projects/kargo-konflux/kustomization.yaml
+++ b/components/kargo/internal-staging/projects/kargo-konflux/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - rbac.yaml
+
+replacements:
+  - source:
+      kind: Namespace
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: Project
+        fieldPaths:
+          - metadata.name
+
+namespace: kargo-konflux

--- a/components/kargo/internal-staging/projects/kargo-konflux/rbac.yaml
+++ b/components/kargo/internal-staging/projects/kargo-konflux/rbac.yaml
@@ -1,0 +1,25 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-kargo-resources-admin
+rules:
+  - apiGroups:
+      - kargo.akuity.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-kargo-resources-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: konflux-devprod-kargo-resources-admin

--- a/components/kargo/internal-staging/projects/kustomization.yaml
+++ b/components/kargo/internal-staging/projects/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - kargo-konflux-infra
   - kargo-konflux-vanguard
+  - kargo-konflux
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
Give permissions to the devprod team to manages Kargo. Also, create a project they can use for experimenting with it.