### PR TITLE
KFLUXINFRA-3597: Update Rover Group Sync with new image

### DIFF
--- a/components/rover-group-sync/base/cronjob.yaml
+++ b/components/rover-group-sync/base/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               emptyDir: {}
           containers:
             - name: rover-group-sync
-              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:706e398edf9489e3027cced5c21987f88869fdf4bc1bac5e35c428279d324083
+              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:3d7a8e738e6564e8833074027030608efc03d3f66c1a3cfec444aa7869bc16b4
               imagePullPolicy: IfNotPresent
               command: ["/bin/bash", "/scripts/sync-rover-groups.sh"]
               securityContext:

--- a/components/rover-group-sync/base/kustomization.yaml
+++ b/components/rover-group-sync/base/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - external-secrets
   - cronjob.yaml
   - namespace.yaml
-  - serviceaccount.yaml
+  - rbac.yaml
 configMapGenerator:
   - name: rover-group-sync-config
     files:

--- a/components/rover-group-sync/base/rbac.yaml
+++ b/components/rover-group-sync/base/rbac.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rover-group-sync-cr
+rules:
+  - apiGroups: ["user.openshift.io"]
+    resources: ["groups"]
+    verbs: ["get", "list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rover-group-sync-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rover-group-sync-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rover-group-sync-cr
+subjects:
+  - kind: ServiceAccount
+    name: rover-group-sync-sa
+    namespace: rover-group-sync

--- a/components/rover-group-sync/base/serviceaccount.yaml
+++ b/components/rover-group-sync/base/serviceaccount.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: rover-group-sync-sa


### PR DESCRIPTION
Includes:
- https://github.com/redhat-appstudio/infrastructure/pull/122

Enable the temporary known_hosts file to be written. Also adds RBAC
resources to enable the rover-group-sync service account to get
OpenShift groups.