### PR TITLE
KFLUXINFRA-3597: Fix Rover Group Sync Secret Paths

### DIFF
--- a/components/rover-group-sync/internal-production/externalsecrets-patch.yaml
+++ b/components/rover-group-sync/internal-production/externalsecrets-patch.yaml
@@ -9,7 +9,7 @@ spec:
     - extract:
         conversionStrategy: Default
         decodingStrategy: None
-        key: production/infrastructure/group-sync/git-repo-creds
+        key: production/infrastructure/group-sync/git-repo-ssh-key
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -21,7 +21,7 @@ spec:
     - extract:
         conversionStrategy: Default
         decodingStrategy: None
-        key: production/infrastructure/group-sync/ldap-creds
+        key: production/infrastructure/group-sync/konflux-ldap-sa
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret


### PR DESCRIPTION
Update the external secrets patch to use the correct secret paths in Vault for the production environment.