### PR TITLE
KFLUXINFRA-3596: Update rover group sync image to use the new directory structure

### DIFF
--- a/components/rover-group-sync/base/cronjob.yaml
+++ b/components/rover-group-sync/base/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               emptyDir: {}
           containers:
             - name: rover-group-sync
-              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:3d7a8e738e6564e8833074027030608efc03d3f66c1a3cfec444aa7869bc16b4
+              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:61ec8cd37f2eaec2cf3d898a8eeae1658e8caa4dd2ffc8d969f086b8dccffe75
               imagePullPolicy: IfNotPresent
               command: ["/bin/bash", "/scripts/sync-rover-groups.sh"]
               securityContext:


### PR DESCRIPTION
Includes:
- https://github.com/redhat-appstudio/infrastructure/pull/124

Testing:
https://github.com/redhat-appstudio/internal-infra-deployments/commit/5abd69a38786b6c682bdfc67079d1eccc07b34d7 shows a successful test run of the new iamge