### PR TITLE
KFLUXINFRA-3694 Add signing priority class and CEL expressions

### DIFF
--- a/components/kueue/internal-staging/queue-config/workload-priority-class.yaml
+++ b/components/kueue/internal-staging/queue-config/workload-priority-class.yaml
@@ -2,6 +2,13 @@
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: WorkloadPriorityClass
 metadata:
+  name: konflux-signing
+value: 950
+description: "High priority for signing pipelines rate-limited via ISV-6622"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
   name: konflux-default
 value: 400
 description: "Default priority for pipelines"

--- a/components/kueue/internal-staging/tekton-kueue/config.yaml
+++ b/components/kueue/internal-staging/tekton-kueue/config.yaml
@@ -2,4 +2,10 @@ queueName: pipelines-queue
 cel:
   expressions:
     - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/rate-limited' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limited'] == 'true' &&
+        'internal-services.appstudio.openshift.io/rate-limiting-group' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limiting-group'] == 'signing-server' ?
+        priority('konflux-signing') :
         priority('konflux-default')


### PR DESCRIPTION
## What
Add a dedicated `konflux-signing` WorkloadPriorityClass (value 950) and update
the tekton-kueue CEL config to assign it to PipelineRuns carrying the [ISV-6622](https://redhat.atlassian.net/browse/ISV-6622)
rate-limiting labels:
- `internal-services.appstudio.openshift.io/rate-limited: "true"`
- `internal-services.appstudio.openshift.io/rate-limiting-group: "signing-server"`

All other pipelines fall back to `konflux-default` (400).

## Why
[ISV-6622](https://redhat.atlassian.net/browse/ISV-6622) replaces a custom scheduler in the internal-services operator with
Kueue for rate-limiting container signing pipelines. Signing pipelines need
their own priority tier so Kueue can distinguish them from general workloads
and enforce appropriate scheduling.

## Validation
- `kustomize build` passes for `components/kueue/internal-staging`

## Risk Assessment
**Risk Level:** Low

Additive change -- introduces one new WorkloadPriorityClass and updates a CEL
config. No existing workloads are affected since the default priority fallback
is unchanged. Signing pipelines will only get the new priority once they start
carrying the [ISV-6622](https://redhat.atlassian.net/browse/ISV-6622) labels.

Made with [Cursor](https://cursor.com)

[ISV-6622]: https://redhat.atlassian.net/browse/ISV-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ISV-6622]: https://redhat.atlassian.net/browse/ISV-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ISV-6622]: https://redhat.atlassian.net/browse/ISV-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ