### PR TITLE
fix(KONFLUX-12922): set namespace via kustomize namespace transformer

### DIFF
--- a/components/internal-services/internal-production/kustomization.yaml
+++ b/components/internal-services/internal-production/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: internal-services
 resources:
   # Core resources now managed directly in production
   - crds/

--- a/components/internal-services/internal-staging/kustomization.yaml
+++ b/components/internal-services/internal-staging/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: internal-services
 
 resources:
   # Core resources now managed directly in staging


### PR DESCRIPTION
kubectl auth reconcile, used by ArgoCD for RBAC resources, requires
an explicit namespace on ServiceAccount subjects in ClusterRoleBindings.

Rather than hardcoding the namespace in the raw YAML files (which would
be overwritten by the update-internal-services automation task), use
kustomize's namespace transformer. This injects the namespace into
ServiceAccount subjects within ClusterRoleBindings at build time and
is resilient to upstream RBAC file updates.

Assisted-by: Cursor