### PR TITLE
KFLUXINFRA-3603: revert ExternalSecret apiVersion to v1beta1

### DIFF
--- a/components/monitoring/logging/base/external-secrets/splunk-log-forwarder-external-secrets.yaml
+++ b/components/monitoring/logging/base/external-secrets/splunk-log-forwarder-external-secrets.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: log-forwarder-splunk-rhtap-application-external-secret
@@ -17,7 +17,7 @@ spec:
     name: log-forwarder-splunk-rhtap-application-secret
     deletionPolicy: Delete
 ---
-apiVersion: external-secrets.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: log-forwarder-splunk-rhtap-audit-external-secret

--- a/components/monitoring/logging/external-production/kustomization.yaml
+++ b/components/monitoring/logging/external-production/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
@@ -16,7 +16,7 @@ patches:
         value: production/monitoring/logging/splunk/rh_rhtap_production_app
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |

--- a/components/monitoring/logging/external-staging/kustomization.yaml
+++ b/components/monitoring/logging/external-staging/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
@@ -16,7 +16,7 @@ patches:
         value: staging/monitoring/logging/splunk/rh_rhtap_stage_app
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |

--- a/components/monitoring/logging/internal-production/kustomization.yaml
+++ b/components/monitoring/logging/internal-production/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
@@ -16,7 +16,7 @@ patches:
         value: production/monitoring/logging/splunk/rh_rhtap_production_app
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |

--- a/components/monitoring/logging/internal-staging/kustomization.yaml
+++ b/components/monitoring/logging/internal-staging/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 patches:
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-application-external-secret
     patch: |
@@ -16,7 +16,7 @@ patches:
         value: staging/monitoring/logging/splunk/rh_rhtap_stage_app
   - target:
       group: external-secrets.io
-      version: v1
+      version: v1beta1
       kind: ExternalSecret
       name: log-forwarder-splunk-rhtap-audit-external-secret
     patch: |


### PR DESCRIPTION
Common clusters (kflux-c-stg-i01, kflux-c-stg-e01) run ESO v0.11.0 with CRDs that only serve v1beta1. The v1 apiVersion introduced in PR #316 broke ArgoCD sync on these clusters (retried 50x, failed with "no matches for kind ExternalSecret in version external-secrets.io/v1").

Revert to v1beta1 to unblock sync while keeping the updated Vault paths.