### PR TITLE
KFLUXINFRA-3694 Add signing-server resource quota and CEL resource request

### DIFF
--- a/components/kueue/internal-staging/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-staging/queue-config/cluster-queue.yaml
@@ -19,9 +19,12 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - signing-server-request
     flavors:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '300'
+        nominalQuota: '500'
+      - name: signing-server-request
+        nominalQuota: '500'
   stopPolicy: None

--- a/components/kueue/internal-staging/tekton-kueue/config.yaml
+++ b/components/kueue/internal-staging/tekton-kueue/config.yaml
@@ -16,4 +16,4 @@ cel:
         pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limited'] == 'true' &&
         'internal-services.appstudio.openshift.io/rate-limiting-group' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limiting-group'] == 'signing-server' ?
-        [resource('signing-server-request', 1)] : []      
+        [resource('signing-server-request', 1)] : []

--- a/components/kueue/internal-staging/tekton-kueue/config.yaml
+++ b/components/kueue/internal-staging/tekton-kueue/config.yaml
@@ -9,3 +9,11 @@ cel:
         pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limiting-group'] == 'signing-server' ?
         priority('konflux-signing') :
         priority('konflux-default')
+
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/rate-limited' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limited'] == 'true' &&
+        'internal-services.appstudio.openshift.io/rate-limiting-group' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limiting-group'] == 'signing-server' ?
+        [resource('signing-server-request', 1)] : []      


### PR DESCRIPTION
## What
Add a virtual `signing-server-request` resource to the Kueue ClusterQueue and
a second CEL expression in the tekton-kueue config that requests one unit of it
for PipelineRuns carrying the [ISV-6622](https://redhat.atlassian.net/browse/ISV-6622) rate-limiting labels:
- `internal-services.appstudio.openshift.io/rate-limited: "true"`
- `internal-services.appstudio.openshift.io/rate-limiting-group: "signing-server"`

This gives signing workloads an independent concurrency limit, separate from the
overall `tekton.dev/pipelineruns` quota. The pipelineruns quota is also bumped
from 300 to 500.

Changes:
- `cluster-queue.yaml`: add `signing-server-request` covered resource with
  `nominalQuota: 500`; bump `tekton.dev/pipelineruns` to 500
- `config.yaml`: add CEL expression that maps signing-labeled PipelineRuns to
  `resource('signing-server-request', 1)`

## Why
[ISV-6622](https://redhat.atlassian.net/browse/ISV-6622) requires rate-limiting signing pipelines to prevent overwhelming the
signing server. A virtual resource quota provides a tunable concurrency knob
that can be adjusted independently of the total pipeline capacity.

## Validation
- Follows the same CEL `resource()` pattern used in
  [infra-deployments kflux-ocp-p01](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/kueue/production/kflux-ocp-p01/config.yaml)
- Both quotas start at 500 for evaluation; will be tuned based on staging
  observations of signing server throughput

## Risk Assessment
**Risk Level:** Low

Additive change to the ClusterQueue and CEL config. Non-signing PipelineRuns are
unaffected -- they don't request the `signing-server-request` resource. The
pipelineruns quota increase (300 → 500) is permissive and can be lowered later.

Made with [Cursor](https://cursor.com)

[ISV-6622]: https://redhat.atlassian.net/browse/ISV-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ISV-6622]: https://redhat.atlassian.net/browse/ISV-6622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ