### PR TITLE
KFLUXINFRA-3694 Simplify to FIFO scheduling for signing pipelines

### DIFF
--- a/components/kueue/internal-staging/queue-config/workload-priority-class.yaml
+++ b/components/kueue/internal-staging/queue-config/workload-priority-class.yaml
@@ -2,13 +2,6 @@
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: WorkloadPriorityClass
 metadata:
-  name: konflux-signing
-value: 950
-description: "High priority for signing pipelines rate-limited via ISV-6622"
----
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: WorkloadPriorityClass
-metadata:
   name: konflux-default
 value: 400
 description: "Default priority for pipelines"

--- a/components/kueue/internal-staging/tekton-kueue/config.yaml
+++ b/components/kueue/internal-staging/tekton-kueue/config.yaml
@@ -2,12 +2,6 @@ queueName: pipelines-queue
 cel:
   expressions:
     - |
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/rate-limited' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limited'] == 'true' &&
-        'internal-services.appstudio.openshift.io/rate-limiting-group' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limiting-group'] == 'signing-server' ?
-        priority('konflux-signing') :
         priority('konflux-default')
 
     - |


### PR DESCRIPTION
## What
Remove the `konflux-signing` WorkloadPriorityClass and simplify the
tekton-kueue CEL priority expression to assign `konflux-default` to all
PipelineRuns unconditionally.

## Why
The signing team requires FIFO scheduling -- pipelines should be processed
in creation-time order regardless of type. A separate signing priority class
would break FIFO ordering between signing and non-signing pipelines.
With a single priority, Kueue's `BestEffortFIFO` strategy handles this
natively.

## Validation
- CEL config passes yamllint
- Only the priority class and CEL priority expression are changed; the
  signing-server-request resource expression is untouched

## Risk Assessment
**Risk Level:** Low

Removes one WorkloadPriorityClass and simplifies CEL logic. No behavioral
change for existing workloads.