### PR TITLE
KFLUXINFRA-3695 Install Kueue v1.3 on internal-production

### DIFF
--- a/components/kueue/internal-production/kueue/kueue.yaml
+++ b/components/kueue/internal-production/kueue/kueue.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks: # The operator requires at lest one framework to be enabled
+      - BatchJob
+      externalFrameworks:
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns

--- a/components/kueue/internal-production/kueue/kustomization.yaml
+++ b/components/kueue/internal-production/kueue/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- operator.yaml
+- kueue.yaml
+namespace: openshift-kueue-operator

--- a/components/kueue/internal-production/kueue/operator.yaml
+++ b/components/kueue/internal-production/kueue/operator.yaml
@@ -40,7 +40,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-v1.2
+  channel: stable-v1.3
   installPlanApproval: Automatic
   name: kueue-operator
   source: redhat-operators-1-18

--- a/components/kueue/internal-production/kueue/operator.yaml
+++ b/components/kueue/internal-production/kueue/operator.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kueue-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  name: redhat-operators-1-18
+  namespace: openshift-kueue-operator
+spec:
+  displayName: redhat-operators-1-18
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kueue-operatorgroup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-kueue-operator
+  namespace: openshift-kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  channel: stable-v1.2
+  installPlanApproval: Automatic
+  name: kueue-operator
+  source: redhat-operators-1-18
+  sourceNamespace: openshift-kueue-operator

--- a/components/kueue/internal-production/kustomization.yaml
+++ b/components/kueue/internal-production/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue
+- localqueues
+- tekton-kueue
+- queue-config
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue/internal-production/localqueues/internal-services.yaml
+++ b/components/kueue/internal-production/localqueues/internal-services.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: internal-services
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterQueue: cluster-pipeline-queue

--- a/components/kueue/internal-production/localqueues/internal-services.yaml
+++ b/components/kueue/internal-production/localqueues/internal-services.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: pipelines-queue

--- a/components/kueue/internal-production/localqueues/kustomization.yaml
+++ b/components/kueue/internal-production/localqueues/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- internal-services.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "11"
+
+# namespace: DO NOT USE THIS FIELD, this allows us to create localqueues for components in more than one namespace

--- a/components/kueue/internal-production/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-production/queue-config/cluster-queue.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-pipeline-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - signing-server-request
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '500'
+      - name: signing-server-request
+        nominalQuota: '500'
+  stopPolicy: None

--- a/components/kueue/internal-production/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-production/queue-config/cluster-queue.yaml
@@ -1,10 +1,10 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue

--- a/components/kueue/internal-production/queue-config/kustomization.yaml
+++ b/components/kueue/internal-production/queue-config/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- workload-priority-class.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/components/kueue/internal-production/queue-config/workload-priority-class.yaml
+++ b/components/kueue/internal-production/queue-config/workload-priority-class.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-default
+value: 400
+description: "Default priority for pipelines"

--- a/components/kueue/internal-production/queue-config/workload-priority-class.yaml
+++ b/components/kueue/internal-production/queue-config/workload-priority-class.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-default

--- a/components/kueue/internal-production/tekton-kueue/config.yaml
+++ b/components/kueue/internal-production/tekton-kueue/config.yaml
@@ -1,0 +1,13 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    - |
+        priority('konflux-default')
+
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/rate-limited' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limited'] == 'true' &&
+        'internal-services.appstudio.openshift.io/rate-limiting-group' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limiting-group'] == 'signing-server' ?
+        [resource('signing-server-request', 1)] : []

--- a/components/kueue/internal-production/tekton-kueue/controller-patch.yaml
+++ b/components/kueue/internal-production/tekton-kueue/controller-patch.yaml
@@ -1,0 +1,49 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 2
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 500m
+    memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 500m
+    memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue/internal-production/tekton-kueue/kustomization.yaml
+++ b/components/kueue/internal-production/tekton-kueue/kustomization.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=815dbf158b0e39df568eb901dcf05e759099991a
+
+images:
+- name: konflux-ci/tekton-kueue
+  newName: quay.io/konflux-ci/tekton-kueue
+  newTag: 815dbf158b0e39df568eb901dcf05e759099991a
+
+namespace: tekton-kueue
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"
+
+configMapGenerator:
+- name: tekton-kueue-config
+  namespace: tekton-kueue
+  behavior: replace
+  files:
+  - config.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+- path: controller-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-controller-manager
+    version: v1
+- path: webhook-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-webhook
+    version: v1
+- target:
+    kind: Namespace
+    name: tekton-kueue
+  patch: |-
+    - op: add
+      path: /metadata/labels/openshift.io~1cluster-monitoring
+      value: "true"

--- a/components/kueue/internal-production/tekton-kueue/kustomization.yaml
+++ b/components/kueue/internal-production/tekton-kueue/kustomization.yaml
@@ -12,7 +12,7 @@ images:
 namespace: tekton-kueue
 
 commonAnnotations:
-  argocd.argoproj.io/sync-wave: "10"
+  argocd.argoproj.io/sync-wave: "12"
 
 configMapGenerator:
 - name: tekton-kueue-config

--- a/components/kueue/internal-production/tekton-kueue/webhook-patch.yaml
+++ b/components/kueue/internal-production/tekton-kueue/webhook-patch.yaml
@@ -1,0 +1,41 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 3
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue-webhook
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 200m
+    memory: 256Mi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 200m
+    memory: 256Mi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --zap-log-level=5

--- a/components/kueue/internal-staging/tekton-kueue/kustomization.yaml
+++ b/components/kueue/internal-staging/tekton-kueue/kustomization.yaml
@@ -12,7 +12,7 @@ images:
 namespace: tekton-kueue
 
 commonAnnotations:
-  argocd.argoproj.io/sync-wave: "10"
+  argocd.argoproj.io/sync-wave: "12"
 
 configMapGenerator:
 - name: tekton-kueue-config


### PR DESCRIPTION
## Summary

- Install Kueue on the internal-production cluster using `stable-v1.3` channel with `v1beta2` CRD apiVersions
- Fix tekton-kueue sync wave ordering (wave 10 → 12) for both internal-staging and internal-production

## Context

Kueue has never been installed on the internal-production cluster. This PR introduces a fresh installation at v1.3.1, aligned with the staging deployment.

### Related PRs

| PR | Description | Status |
|----|-------------|--------|
| #344 | Remove Kueue staging resources (teardown for v1.3 upgrade) | Merged |
| #342 | Install Kueue v1.3 on internal-staging (fresh reinstall) | Merged |
| #343 | Add CI to validate tekton-kueue CEL expressions | Open |
| #340 | Simplify to FIFO scheduling for signing pipelines | Merged |
| #337 | Add signing-server resource quota and CEL resource request | Merged |

## Changes

### Production install (new files)

- `kueue/` — Namespace, CatalogSource (v4.18 index), OperatorGroup, Subscription (`stable-v1.3`), Kueue CR with Tekton PipelineRun framework
- `queue-config/` — ClusterQueue (`cluster-pipeline-queue`) with `signing-server-request` resource + WorkloadPriorityClass (`v1beta2`)
- `localqueues/` — LocalQueue (`pipelines-queue`) in `internal-services` namespace (`v1beta2`)
- `tekton-kueue/` — Controller (2 replicas) and webhook (3 replicas) with topology spread, resource limits, and leader election tuning

### Sync wave fix (both environments)

tekton-kueue sync wave moved from 10 → 12 so it deploys **after** LocalQueue (wave 11), preventing a race where the webhook starts before `pipelines-queue` exists.

### Sync wave ordering

| Wave | Component | Purpose |
|------|-----------|---------|
| -4 to -1 | `kueue/` | Namespace, CatalogSource, OperatorGroup, Subscription |
| 1 | Kueue CR | Operator instance |
| 10 | `queue-config/` | ClusterQueue, ResourceFlavor, WorkloadPriorityClass |
| 11 | `localqueues/` | LocalQueue in internal-services |
| 12 | `tekton-kueue/` | Controller + webhook (must deploy after LocalQueue) |

## Note

Both environments are kept independent (no shared base overlay) to allow independent tuning — per team agreement.