### PR TITLE
KFLUXINFRA-3694 Install Kueue v1.3 on internal-staging

### DIFF
--- a/components/kueue/internal-staging/kueue/operator.yaml
+++ b/components/kueue/internal-staging/kueue/operator.yaml
@@ -40,7 +40,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-v1.2
+  channel: stable-v1.3
   installPlanApproval: Automatic
   name: kueue-operator
   source: redhat-operators-1-18

--- a/components/kueue/internal-staging/kustomization.yaml
+++ b/components/kueue/internal-staging/kustomization.yaml
@@ -1,4 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+- kueue
+- localqueues
+- tekton-kueue
+- queue-config
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue/internal-staging/localqueues/internal-services.yaml
+++ b/components/kueue/internal-staging/localqueues/internal-services.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: pipelines-queue

--- a/components/kueue/internal-staging/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-staging/queue-config/cluster-queue.yaml
@@ -1,10 +1,10 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue

--- a/components/kueue/internal-staging/queue-config/workload-priority-class.yaml
+++ b/components/kueue/internal-staging/queue-config/workload-priority-class.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-default


### PR DESCRIPTION
## Summary

- Reinstalls Kueue on internal-staging using the `stable-v1.3` channel after the full teardown in PR #344.
- Configures all Kueue CRDs with `v1beta2` API versions (ResourceFlavor, ClusterQueue, WorkloadPriorityClass, LocalQueue).
- Restores the kustomization resource references to deploy the complete Kueue stack.

## Context

The previous v1.2.0 installation was removed in PR #344 because OLM had no upgrade edge from v1.2.0 to v1.3. With a clean slate, OLM will now perform a fresh install of v1.3.1 directly from the `stable-v1.3` channel.

## Changes

1. **Operator subscription:** `channel: stable-v1.3` (fresh OLM install of v1.3.1)
2. **CRD API versions:** All Kueue resources bumped from `v1beta1` → `v1beta2`
3. **Kustomization:** Resource list restored to deploy kueue, localqueues, tekton-kueue, and queue-config

## What happens when this merges

1. ArgoCD syncs the restored kustomization → deploys all Kueue resources
2. OLM sees a new Subscription on `stable-v1.3` → installs v1.3.1 fresh (no upgrade path needed)
3. Kueue CRDs (v1beta2) become available → tekton-kueue starts successfully
4. PipelineRun admission resumes on staging

## Impact

- Staging Kueue is restored with v1.3.1
- No impact on production