### PR TITLE
KFLUXINFRA-3694 Remove Kueue staging resources for v1.3 upgrade

### DIFF
--- a/components/kueue/internal-staging/kustomization.yaml
+++ b/components/kueue/internal-staging/kustomization.yaml
@@ -1,11 +1,4 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- kueue
-- localqueues
-- tekton-kueue
-- queue-config
-
-commonAnnotations:
-  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+resources: []


### PR DESCRIPTION
## Summary

- Empties the `components/kueue/internal-staging/kustomization.yaml` resource list to trigger ArgoCD pruning of all Kueue-managed resources on staging clusters.
- OLM has **no upgrade edge from v1.2.0 → v1.3**, so the v1.2.0 CSV cannot be upgraded in-place. A full teardown is required before reinstalling on `stable-v1.3`.
- Subdirectory files (kueue/, localqueues/, queue-config/, tekton-kueue/) are intentionally kept for easy rebasing of PR #342 after this merges.

## Context

The `stable-v1.3` channel subscription caused an OLM stall:
- OLM cannot find an upgrade path from `kueue-operator.v1.2.0` to v1.3.x
- `tekton-kueue` has 1 pod in CrashLoopBackOff (needs v1beta2 CRDs from v1.3)
- Old tekton-kueue pods still serve traffic — **no current outage**

## What happens when this merges

1. ArgoCD syncs the empty kustomization → produces zero desired resources
2. `syncPolicy.automated.prune: true` deletes all previously managed resources:
   - tekton-kueue controller + webhook (resolves CrashLoopBackOff)
   - LocalQueue, ClusterQueue, WorkloadPriorityClass
   - Kueue CR, Subscription, OperatorGroup, CatalogSource
   - **Namespace `openshift-kueue-operator`** → cascading delete removes the stuck v1.2.0 CSV
3. Kueue is fully removed from staging

## Re-installation plan

After this PR merges, PR #342 will be rebased on `main` to re-add the Kueue configuration with:
- `channel: stable-v1.3` (fresh OLM install of v1.3.1)
- `v1beta2` API versions for all Kueue CRs

## Impact

- **Brief downtime** for new PipelineRun admissions on staging (between prune completing and PR #342 re-install)
- Existing running pipelines are unaffected
- No impact on production


Made with [Cursor](https://cursor.com)