### PR TITLE
fix: restore signing-pipeline-sa in internal-production RBAC kustomization

### DIFF
--- a/components/internal-services/internal-production/rbac/kustomization.yaml
+++ b/components/internal-services/internal-production/rbac/kustomization.yaml
@@ -7,22 +7,23 @@ resources:
 # if your manager will use a service account that exists at
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
-  - service_account.yaml
-  - role.yaml
-  - role_binding.yaml
-  - leader_election_role.yaml
-  - leader_election_role_binding.yaml
+ - service_account.yaml
+ - role.yaml
+ - role_binding.yaml
+ - leader_election_role.yaml
+ - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-  - auth_proxy_service.yaml
-  - auth_proxy_role.yaml
-  - auth_proxy_role_binding.yaml
-  - auth_proxy_client_clusterrole.yaml
-  - internalrequest_editor_role.yaml
-  - internalrequest_viewer_role.yaml
-  - internalservicesconfig_editor_role.yaml
-  - internalservicesconfig_viewer_role.yaml
-  - view-authenticated-users.yaml
-  - release_team_role.yaml
-  - release_team_role_binding.yaml
+ - auth_proxy_service.yaml
+ - auth_proxy_role.yaml
+ - auth_proxy_role_binding.yaml
+ - auth_proxy_client_clusterrole.yaml
+ - internalrequest_editor_role.yaml
+ - internalrequest_viewer_role.yaml
+ - internalservicesconfig_editor_role.yaml
+ - internalservicesconfig_viewer_role.yaml
+ - view-authenticated-users.yaml
+ - release_team_role.yaml
+ - release_team_role_binding.yaml
+ - signing-sa.yaml

--- a/components/internal-services/internal-production/rbac/kustomization.yaml
+++ b/components/internal-services/internal-production/rbac/kustomization.yaml
@@ -7,23 +7,23 @@ resources:
 # if your manager will use a service account that exists at
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
- - service_account.yaml
- - role.yaml
- - role_binding.yaml
- - leader_election_role.yaml
- - leader_election_role_binding.yaml
+  - service_account.yaml
+  - role.yaml
+  - role_binding.yaml
+  - leader_election_role.yaml
+  - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
- - auth_proxy_service.yaml
- - auth_proxy_role.yaml
- - auth_proxy_role_binding.yaml
- - auth_proxy_client_clusterrole.yaml
- - internalrequest_editor_role.yaml
- - internalrequest_viewer_role.yaml
- - internalservicesconfig_editor_role.yaml
- - internalservicesconfig_viewer_role.yaml
- - view-authenticated-users.yaml
- - release_team_role.yaml
- - release_team_role_binding.yaml
- - signing-sa.yaml
+  - auth_proxy_service.yaml
+  - auth_proxy_role.yaml
+  - auth_proxy_role_binding.yaml
+  - auth_proxy_client_clusterrole.yaml
+  - internalrequest_editor_role.yaml
+  - internalrequest_viewer_role.yaml
+  - internalservicesconfig_editor_role.yaml
+  - internalservicesconfig_viewer_role.yaml
+  - view-authenticated-users.yaml
+  - release_team_role.yaml
+  - release_team_role_binding.yaml
+  - signing-sa.yaml


### PR DESCRIPTION
## Summary

`components/internal-services/internal-production/rbac/signing-sa.yaml` defines `signing-pipeline-sa`, but **`kustomization.yaml` stopped listing it**, so Kustomize/GitOps no longer applied the ServiceAccount.

## Root cause

[#287](https://github.com/redhat-appstudio/infra-common-deployments/pull/287) (*chore: update internal-services resources for production*) dropped the `- signing-sa.yaml` resource entry while syncing manifests. The parent commit still included it.

## Change

Re-add:

```yaml
 - signing-sa.yaml
```

to `internal-production/rbac/kustomization.yaml`.
