### PR TITLE
fix(internal-production): re-add signing-sa RBAC resource

### DIFF
--- a/components/internal-services/internal-production/rbac/kustomization.yaml
+++ b/components/internal-services/internal-production/rbac/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
   - view-authenticated-users.yaml
   - release_team_role.yaml
   - release_team_role_binding.yaml
+  - signing-sa.yaml


### PR DESCRIPTION
**Issue:** `signing-pipeline-sa` was not applied because `internal-production/rbac/kustomization.yaml` omitted `signing-sa.yaml` (the manifest is still in-repo).

**Cause:** Dropped in [#287](https://github.com/redhat-appstudio/infra-common-deployments/pull/287) during internal-services production sync.

**Fix:** Add `  - signing-sa.yaml` under `resources`.