### PR TITLE
 KFLUXINFRA-3596: Update production rover group sync cronjob image

### DIFF
--- a/components/rover-group-sync/base/cronjob.yaml
+++ b/components/rover-group-sync/base/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
               emptyDir: {}
           containers:
             - name: rover-group-sync
-              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:61ec8cd37f2eaec2cf3d898a8eeae1658e8caa4dd2ffc8d969f086b8dccffe75
+              image: quay.io/redhat-user-workloads/konflux-infra-tenant/rover-group-sync@sha256:b6c92fda223f0e9a064d9d618053fb8563a077f19b079fd123b9d3a1faf093be
               imagePullPolicy: IfNotPresent
               command: ["/bin/bash", "/scripts/sync-rover-groups.sh"]
               securityContext:

--- a/components/rover-group-sync/internal-production/kustomization.yaml
+++ b/components/rover-group-sync/internal-production/kustomization.yaml
@@ -1,8 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rover-group-sync
+
+images:
+- name: rover-group-sync
+  digest: sha256:b6c92fda223f0e9a064d9d618053fb8563a077f19b079fd123b9d3a1faf093be
+
 resources:
   - ../base
+
 patches:
   - path: cronjob-patch.yaml
     target:


### PR DESCRIPTION
Included changes:
- https://github.com/redhat-appstudio/infrastructure/pull/134

Tested in staging in https://github.com/redhat-appstudio/infra-common-deployments/pull/350