### PR TITLE
fix: codecov: prevent worker OOMKill crash loop

### DIFF
--- a/components/codecov/internal-staging/codecov.yaml
+++ b/components/codecov/internal-staging/codecov.yaml
@@ -158,10 +158,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 512Mi
-            limits:
-              cpu: "1"
               memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
           volumeMounts:
             - name: codecov-config
               mountPath: /config

--- a/components/codecov/internal-staging/resource-quota.yaml
+++ b/components/codecov/internal-staging/resource-quota.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: codecov
 spec:
   hard:
-    requests.cpu: "2"
-    requests.memory: 4Gi
-    limits.cpu: "4"
-    limits.memory: 4Gi
+    requests.cpu: "3"
+    requests.memory: 6Gi
+    limits.cpu: "6"
+    limits.memory: 6Gi
     persistentvolumeclaims: "4"
     requests.storage: 40Gi


### PR DESCRIPTION
The worker pod was being OOMKilled every ~4 minutes while parsing large coverage reports from uhc-clusters-service, preventing MR comments from being posted for ~15 days. Bumped worker limits from 1Gi to 2Gi and updated ResourceQuota accordingly.