### PR TITLE
fix(internal-staging): re-add signing-sa RBAC resource

### DIFF
--- a/components/internal-services/internal-staging/rbac/kustomization.yaml
+++ b/components/internal-services/internal-staging/rbac/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
   - view-authenticated-users.yaml
   - release_team_role.yaml
   - release_team_role_binding.yaml
+  - signing-sa.yaml


### PR DESCRIPTION
Include signing-sa.yaml in the staging internal-services RBAC kustomization so GitOps applies signing-pipeline-sa (same pattern as prod #347). community-catalog [#81 ](https://github.com/konflux-ci/community-catalog/pull/81)ensures automation won't drop it again.