### PR TITLE
Add test-platform-ci-admins to group sync

### DIFF
--- a/components/rover-group-sync/base/config/ldap-sync-config.yaml
+++ b/components/rover-group-sync/base/config/ldap-sync-config.yaml
@@ -21,7 +21,7 @@ rfc2307:
     baseDN: "ou=adhoc,ou=managedGroups,dc=redhat,dc=com"
     derefAliases: never
     scope: sub
-    filter: (&(objectClass=rhatRoverGroup)(|(cn=konflux-*)(cn=ai-konflux-user-support)(cn=plm-poe)))
+    filter: (&(objectClass=rhatRoverGroup)(|(cn=konflux-*)(cn=ai-konflux-user-support)(cn=plm-poe)(cn=test-platform-ci-admins)))
   groupUIDAttribute: dn
   groupNameAttributes:
     - cn


### PR DESCRIPTION
In infra-deployments, we have 2 GroupSync CRs, this rover group belong to the 2nd CR, add it here to make sure we get this group on all clusters.

[KFLUXINFRA-3596](https://redhat.atlassian.net/browse/KFLUXINFRA-3596)

[KFLUXINFRA-3596]: https://redhat.atlassian.net/browse/KFLUXINFRA-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ