### PR TITLE
Remove wild card from staging rover sync

### DIFF
--- a/components/rover-group-sync/internal-staging/kustomization.yaml
+++ b/components/rover-group-sync/internal-staging/kustomization.yaml
@@ -8,3 +8,12 @@ images:
 
 resources:
   - ../base
+
+# Narrow LDAP group sync for staging only (production keeps base konflux-* filter).
+configMapGenerator:
+  - name: rover-group-sync-config
+    behavior: merge
+    files:
+      - ldap-sync-config.yaml=./ldap-sync-config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/rover-group-sync/internal-staging/ldap-sync-config.yaml
+++ b/components/rover-group-sync/internal-staging/ldap-sync-config.yaml
@@ -1,0 +1,40 @@
+# OpenShift LDAP sync config for: oc adm groups sync --sync-config=...
+# Mirrors components/authentication/base/group-sync/konflux-rover-groups.yaml (RFC2307).
+#
+# Replace:
+#  - url: use IT-approved internal LDAP (ldapfrac was decommissioned for external use)
+#  - bindDN / bindPassword: from the same material as konflux-ldap-sa (Vault path in ExternalSecret)
+#  - ca: path to PEM bundle that validates the LDAP server cert (same trust as mtls-ca-validators)
+#
+# Do not commit real credentials; inject at runtime (CronJob volume from Secret).
+#
+# Staging uses an explicit group allowlist (narrower than production konflux-*).
+
+kind: LDAPSyncConfig
+apiVersion: v1
+url: ldaps://ldap.corp.redhat.com
+bindDN: "REPLACE_WITH_BIND_DN"
+bindPassword: "REPLACE_WITH_BIND_PASSWORD"
+insecure: false
+ca: "REPLACE_WITH_CA_PATH"
+
+rfc2307:
+  groupsQuery:
+    baseDN: "ou=adhoc,ou=managedGroups,dc=redhat,dc=com"
+    derefAliases: never
+    scope: sub
+    filter: '(&(objectClass=rhatRoverGroup)(|(cn=konflux-admins)(cn=konflux-build)(cn=konflux-build-admins)(cn=konflux-contributors)(cn=konflux-cost-management-admins)(cn=konflux-devprod)(cn=konflux-ec)(cn=konflux-grafana-viewers)(cn=konflux-infra)(cn=konflux-integration)(cn=konflux-kubearchive)(cn=konflux-migration)(cn=konflux-mintmaker-team)(cn=konflux-o11y)(cn=konflux-o11y-admins)(cn=konflux-performance)(cn=konflux-pipeline-service)(cn=konflux-qe)(cn=konflux-qe-admins)(cn=konflux-release-team)(cn=konflux-sre)(cn=konflux-support)(cn=konflux-support-ops)(cn=konflux-ui)(cn=konflux-vanguard)(cn=ai-konflux-user-support)(cn=plm-poe)(cn=test-platform-ci-admins)))'
+  groupUIDAttribute: dn
+  groupNameAttributes:
+    - cn
+  groupMembershipAttributes:
+    - uniqueMember
+  usersQuery:
+    baseDN: "dc=redhat,dc=com"
+    derefAliases: never
+    scope: sub
+  userNameAttributes:
+    - uid
+  userUIDAttribute: dn
+  tolerateMemberNotFoundErrors: true
+  tolerateMemberOutOfScopeErrors: true


### PR DESCRIPTION
At the time of rolling out rover group sync using group-sync-operator, it felt like a good idea to sync the konflux groups using a wild card. The worst case back then was some k8s groups created but not used in RBACS.

Now that we transitioned to k8s groups defined in a repo, getting updates at the repo level for a bunch of konflux-* groups not used in RBACs feels wrong, will generate noise and confusion.

Change the sync to a list of groups that we actually use in konflux RBACs for staging, if all goes well prod will be done right after.

The only downside of this change, from now one to add a new rover group in konflux RBACS, this filter will need to be updated but I think the pro outweigh the con.