### PR TITLE
KFLUXINFRA-3596: Deploy k8s groups

### DIFF
--- a/argo-cd-apps/base/all-clusters/k8s-groups/appset.yaml
+++ b/argo-cd-apps/base/all-clusters/k8s-groups/appset.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: k8s-groups
+spec:
+  goTemplate: true
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/k8s-groups
+          environment: ""
+          useCaseDir: rover
+  template:
+    metadata:
+      name: k8s-groups-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        # Since this app is located in another repository, we need to trim the prefix of the environment
+        # to get the correct path.
+        path: '{{values.sourceRoot}}/{{trimPrefix "external-" (trimPrefix "internal-" .values.environment)}}/{{values.useCaseDir}}'
+        repoURL: https://github.com/redhat-appstudio/internal-infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: k8s-groups
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/all-clusters/k8s-groups/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/k8s-groups/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- appset.yaml

--- a/argo-cd-apps/base/all-clusters/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - cluster-secret-store
   - external-secrets-operator
   - iam
+  - k8s-groups
   - monitoring-workload-logging


### PR DESCRIPTION
Add a new application set to deploy the k8s groups located in the internal-infra-deployments
repository to the common Konflux clusters.

Depends on https://gitlab.cee.redhat.com/konflux/infra/-/merge_requests/636 so Groups can be edited.
