### PR TITLE
KFLUXINFRA-3596: Fix template variable names in k8s-groups appset

### DIFF
--- a/argo-cd-apps/base/all-clusters/k8s-groups/appset.yaml
+++ b/argo-cd-apps/base/all-clusters/k8s-groups/appset.yaml
@@ -12,13 +12,13 @@ spec:
           useCaseDir: rover
   template:
     metadata:
-      name: k8s-groups-{{nameNormalized}}
+      name: k8s-groups-{{.nameNormalized}}
     spec:
       project: default
       source:
         # Since this app is located in another repository, we need to trim the prefix of the environment
         # to get the correct path.
-        path: '{{values.sourceRoot}}/{{trimPrefix "external-" (trimPrefix "internal-" .values.environment)}}/{{values.useCaseDir}}'
+        path: '{{.values.sourceRoot}}/{{trimPrefix "external-" (trimPrefix "internal-" .values.environment)}}/{{.values.useCaseDir}}'
         repoURL: https://github.com/redhat-appstudio/internal-infra-deployments.git
         targetRevision: main
       destination:


### PR DESCRIPTION
Go Templating requires variables to be referenced with `.`s. That is fixed in this commit.