### PR TITLE
KFLUXINFRA-3596: Add GitHub ArgoCD ExternalSecret to k8s-groups

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -42,6 +42,7 @@ jobs:
           find argo-cd-apps components -name 'kustomization.yaml' \
             ! -path 'components/kargo/*' \
             ! -path 'components/konflux-devlake/*' \
+            | -path 'components/k8s-groups/*' \
             | xargs -I {} -n1 -P8 bash -c '
               dir=$(dirname "{}")
               output_file=$(echo $dir | tr / -)-kustomization.yaml

--- a/argo-cd-apps/base/all-clusters/k8s-groups/appset.yaml
+++ b/argo-cd-apps/base/all-clusters/k8s-groups/appset.yaml
@@ -3,23 +3,19 @@ kind: ApplicationSet
 metadata:
   name: k8s-groups
 spec:
-  goTemplate: true
   generators:
     - clusters:
         values:
           sourceRoot: components/k8s-groups
           environment: ""
-          useCaseDir: rover
   template:
     metadata:
       name: k8s-groups-{{nameNormalized}}
     spec:
       project: default
       source:
-        # Since this app is located in another repository, we need to trim the prefix of the environment
-        # to get the correct path.
-        path: '{{values.sourceRoot}}/{{trimPrefix "external-" (trimPrefix "internal-" .values.environment)}}/{{values.useCaseDir}}'
-        repoURL: https://github.com/redhat-appstudio/internal-infra-deployments.git
+        path: '{{values.sourceRoot}}/components/k8s-groups/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
         targetRevision: main
       destination:
         namespace: k8s-groups

--- a/components/k8s-groups/internal-staging/gh-argocd-appstudio-externalsecret.yaml
+++ b/components/k8s-groups/internal-staging/gh-argocd-appstudio-externalsecret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github-argocd-appstudio-externalsecret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+  - extract:
+      key: "staging/infrastructure/github-argocd/kflux-c-stg-i01/redhat-appstudio"
+  refreshInterval: 1h
+  secretStoreRef:
+    name: appsre-stonesoup-vault
+    kind: ClusterSecretStore
+  target:
+    name: github-argocd-appstudio-secret
+    deletionPolicy: Delete

--- a/components/k8s-groups/internal-staging/kustomization.yaml
+++ b/components/k8s-groups/internal-staging/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gh-argocd-appstudio-externalsecret.yaml
+  - https://github.com/redhat-appstudio/internal-infra-deployments.git/components/k8s-groups/staging/rover?ref=latest
+  
+namespace: k8s-groups


### PR DESCRIPTION
In order to deploy the k8s-groups application from the internal-infra-deployments repository, we need to provide ArgoCD with the GitHub repo credentials to do so. This adds an ExternalSecret for the entire Red Hat AppStudio GitHub organization.