### PR TITLE
KFLUXINFRA-3596: Deploy ArgoCD Repo Secrets app to internal staging

### DIFF
--- a/argo-cd-apps/base/all-clusters/argocd-repo-secrets/appset.yaml
+++ b/argo-cd-apps/base/all-clusters/argocd-repo-secrets/appset.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: argocd-repo-secrets
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/argocd-repo-secrets
+          environment: ""
+  template:
+    metadata:
+      name: argocd-repo-secrets-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: argocd-local # Must be the same namespace as the ArgoCD instance
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/base/all-clusters/argocd-repo-secrets/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/argocd-repo-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset.yaml

--- a/argo-cd-apps/base/all-clusters/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - argocd-repo-secrets
   - cluster-secret-store
   - external-secrets-operator
   - iam

--- a/argo-cd-apps/overlays/external-production/delete-argocd-repo-secrets-appset.yaml
+++ b/argo-cd-apps/overlays/external-production/delete-argocd-repo-secrets-appset.yaml
@@ -1,0 +1,6 @@
+# argocd-repo-secrets is currently only being tested in internal-staging
+$patch: delete
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: argocd-repo-secrets

--- a/argo-cd-apps/overlays/external-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/external-production/kustomization.yaml
@@ -11,3 +11,9 @@ patches:
       group: argoproj.io
       version: v1alpha1
       kind: ApplicationSet
+  - path: delete-argocd-repo-secrets-appset.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet
+      name: argocd-repo-secrets

--- a/argo-cd-apps/overlays/external-staging/delete-argocd-repo-secrets-appset.yaml
+++ b/argo-cd-apps/overlays/external-staging/delete-argocd-repo-secrets-appset.yaml
@@ -1,0 +1,6 @@
+# argocd-repo-secrets is currently only being tested in internal-staging
+$patch: delete
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: argocd-repo-secrets

--- a/argo-cd-apps/overlays/external-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/external-staging/kustomization.yaml
@@ -11,3 +11,9 @@ patches:
       group: argoproj.io
       version: v1alpha1
       kind: ApplicationSet
+  - path: delete-argocd-repo-secrets-appset.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet
+      name: argocd-repo-secrets

--- a/argo-cd-apps/overlays/internal-production/delete-argocd-repo-secrets-appset.yaml
+++ b/argo-cd-apps/overlays/internal-production/delete-argocd-repo-secrets-appset.yaml
@@ -1,0 +1,6 @@
+# argocd-repo-secrets is currently only being tested in internal-staging
+$patch: delete
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: argocd-repo-secrets

--- a/argo-cd-apps/overlays/internal-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/internal-production/kustomization.yaml
@@ -11,3 +11,9 @@ patches:
       group: argoproj.io
       version: v1alpha1
       kind: ApplicationSet
+  - path: delete-argocd-repo-secrets-appset.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet
+      name: argocd-repo-secrets

--- a/components/argocd-repo-secrets/OWNERS
+++ b/components/argocd-repo-secrets/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+  - hugares
+  - enkeefe00
+  - sadlerap
+  - filariow
+  - mshaposhnik
+  - manish-jangra
+
+reviewers:
+  - hugares
+  - enkeefe00
+  - sadlerap
+  - filariow
+  - mshaposhnik
+  - manish-jangra

--- a/components/argocd-repo-secrets/README.md
+++ b/components/argocd-repo-secrets/README.md
@@ -1,0 +1,8 @@
+# ArgoCD Repository Secrets
+
+The ArgoCD Repository Secrets component consists of ExternalSecrets that allow the common Konflux clusters to deploy resources from any private repository in the [redhat-appstudio GitHub organization](https://github.com/redhat-appstudio).
+
+
+## Secrets and Configurations (Vault)
+
+External Secrets sync from Vault (via `appsre-stonesoup-vault`) into Kubernetes `Secret`s. Paths are under `<environment>/infrastructure/github-argocd/<cluster_name>`. See the [Argo CD docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories) for more information on configuring repositories for ArgoCD.

--- a/components/argocd-repo-secrets/internal-staging/kustomization.yaml
+++ b/components/argocd-repo-secrets/internal-staging/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - redhat-appstudio-externalsecret.yaml
+
+namespace: argocd-local

--- a/components/argocd-repo-secrets/internal-staging/redhat-appstudio-externalsecret.yaml
+++ b/components/argocd-repo-secrets/internal-staging/redhat-appstudio-externalsecret.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redhat-appstudio-externalsecret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/infrastructure/github-argocd/kflux-c-stg-i01/redhat-appstudio
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: redhat-appstudio-secret

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -34,3 +34,4 @@ spec:
         - openshift-logging
         - konflux-support-ops
         - rover-group-sync
+        - argocd-local # Must be the namespace where ArgoCD is deployed


### PR DESCRIPTION
This adds an ApplicationSet to deploy ArgoCD GitHub repository secrets to allow ArgoCD instances in any common Konflux cluster to deploy resources from any private repository in the redhat-appstudio GitHub organization. Only deploy to internal staging for testing; this will need to be used for deploying the k8s-groups application on common clusters.