### PR TITLE
KFLUXINFRA-3596: Add secret-type label to ArgoCD Repo Secrets secret

### DIFF
--- a/components/argocd-repo-secrets/internal-staging/redhat-appstudio-externalsecret.yaml
+++ b/components/argocd-repo-secrets/internal-staging/redhat-appstudio-externalsecret.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: repository
 spec:
   dataFrom:
     - extract:


### PR DESCRIPTION
Adds the argocd.argoproj.io/secret-type label to the ArgoCD Repo Secrets ExternalSecret to allow ArgoCD to properly sync the secret.