### PR TITLE
Add External Secret to Kargo DevProd POC

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -35,3 +35,5 @@ spec:
         - konflux-support-ops
         - rover-group-sync
         - argocd-local # Must be the namespace where ArgoCD is deployed
+        - konflux-devprod-poc
+

--- a/components/kargo/internal-staging/projects/base/kustomization.yaml
+++ b/components/kargo/internal-staging/projects/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - project.yaml
   - ns.yaml
+  - rbac.yaml
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kargo/internal-staging/projects/konflux-devprod-poc/external-secrets/konflux-devprod-poc-secrets.yaml
+++ b/components/kargo/internal-staging/projects/konflux-devprod-poc/external-secrets/konflux-devprod-poc-secrets.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: konflux-devprod-poc-secrets
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/devprod/kargo-secrets-stage
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: konflux-devprod-poc-secrets
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git

--- a/components/kargo/internal-staging/projects/konflux-devprod-poc/external-secrets/kustomization.yaml
+++ b/components/kargo/internal-staging/projects/konflux-devprod-poc/external-secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - konflux-devprod-poc-secrets.yaml

--- a/components/kargo/internal-staging/projects/konflux-devprod-poc/kustomization.yaml
+++ b/components/kargo/internal-staging/projects/konflux-devprod-poc/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - rbac.yaml
+  - external-secrets
+
+replacements:
+  - source:
+      kind: Namespace
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: Project
+        fieldPaths:
+          - metadata.name
+
+namespace: konflux-devprod-poc

--- a/components/kargo/internal-staging/projects/konflux-devprod-poc/rbac.yaml
+++ b/components/kargo/internal-staging/projects/konflux-devprod-poc/rbac.yaml
@@ -1,0 +1,41 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-kargo-resources-admin
+rules:
+  - apiGroups:
+      - kargo.akuity.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - externalsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-kargo-resources-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: konflux-devprod-kargo-resources-admin

--- a/components/kargo/internal-staging/projects/kustomization.yaml
+++ b/components/kargo/internal-staging/projects/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - kargo-konflux-infra
   - kargo-konflux-vanguard
   - kargo-konflux
+  - konflux-devprod-poc
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
The Kargo project "konflux-devprod-poc" needs to access its secret from Vault.