### PR TITLE
fix: disable debug mode

### DIFF
--- a/components/internal-services/internal-staging/config/internal-services-config.yaml
+++ b/components/internal-services/internal-staging/config/internal-services-config.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   allowList:
   - managed-release-team-tenant
-  debug: true
+  debug: false
   volumeClaim:
     name: pipeline
     size: 1Gi


### PR DESCRIPTION
this PR disables the debug mode for internal-services-controller in stage clusters, to allow PipelineRuns to be deleted by the reconciler.