### PR TITLE
KFLUXINFRA-3596: Update ArgoCD Repo Secrets secret type label

### DIFF
--- a/components/argocd-repo-secrets/internal-staging/redhat-appstudio-externalsecret.yaml
+++ b/components/argocd-repo-secrets/internal-staging/redhat-appstudio-externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-1"
   labels:
-    argocd.argoproj.io/secret-type: repository
+    argocd.argoproj.io/secret-type: repo-creds
 spec:
   dataFrom:
     - extract:


### PR DESCRIPTION
Updates the `argocd.argoproj.io/secret-type` label to "repo-creds" to allow ArgoCD to properly sync the secret for the appstudio organization. This changes the label from allowing a single repo to the whole organization.