### PR TITLE
Deploy Prometheus observability stack to staging common clusters

### DIFF
--- a/argo-cd-apps/base/all-clusters/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - iam
   - k8s-groups
   - monitoring-workload-logging
+  - monitoring-workload-prometheus

--- a/argo-cd-apps/base/all-clusters/monitoring-workload-prometheus/appset.yaml
+++ b/argo-cd-apps/base/all-clusters/monitoring-workload-prometheus/appset.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: monitoring-workload-prometheus
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/monitoring/prometheus
+          environment: ""
+  template:
+    metadata:
+      name: monitoring-workload-prometheus-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: appstudio-monitoring
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/base/all-clusters/monitoring-workload-prometheus/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/monitoring-workload-prometheus/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset.yaml

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -27,6 +27,7 @@ spec:
             namespace: appsre-vault
   conditions:
     - namespaces:
+        - appstudio-monitoring
         - codecov
         - internal-services
         - konflux-devlake

--- a/components/monitoring/prometheus/external-production/kustomization.yaml
+++ b/components/monitoring/prometheus/external-production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Placeholder: full production stack will be added after staging is validated.
+resources:
+  - namespace.yaml

--- a/components/monitoring/prometheus/external-production/namespace.yaml
+++ b/components/monitoring/prometheus/external-production/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-monitoring

--- a/components/monitoring/prometheus/external-staging/federation-rbac.yaml
+++ b/components/monitoring/prometheus/external-staging/federation-rbac.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appstudio-federate-ms-view
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: appstudio-federate-ms-prometheus
+  namespace: appstudio-monitoring

--- a/components/monitoring/prometheus/external-staging/federation-smon.yaml
+++ b/components/monitoring/prometheus/external-staging/federation-smon.yaml
@@ -1,0 +1,217 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: appstudio-federate-smon
+  namespace: appstudio-monitoring
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: observability-operator
+      app.kubernetes.io/name: appstudio-federate-ms-prometheus
+  endpoints:
+  - params:
+      'match[]':
+
+      # =================================================================
+      # Deployment Status (common-cluster namespaces)
+      # =================================================================
+
+      # Namespace: appstudio-monitoring
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="appstudio-monitoring"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="appstudio-monitoring"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="appstudio-monitoring"}'
+
+      # Namespace: argocd-local
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="argocd-local"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="argocd-local"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="argocd-local"}'
+
+      # Namespace: cert-manager / cert-manager-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~"cert-manager.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~"cert-manager.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~"cert-manager.*"}'
+
+      # Namespace: external-secrets-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="external-secrets-operator"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="external-secrets-operator"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="external-secrets-operator"}'
+
+      # Namespace: kargo and kargo-*
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~"kargo.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~"kargo.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~"kargo.*"}'
+
+      # Namespace: konflux-devlake
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-devlake"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-devlake"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-devlake"}'
+
+      # Namespace: konflux-kyverno
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-kyverno"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-kyverno"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-kyverno"}'
+
+      # Namespace: konflux-policies
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-policies"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-policies"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-policies"}'
+
+      # Namespace: konflux-portal-server
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-portal-server"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-portal-server"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-portal-server"}'
+
+      # Namespace: konflux-support-ops / konflux-support-ops-dashboard
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~"konflux-support-ops.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~"konflux-support-ops.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~"konflux-support-ops.*"}'
+
+      # Namespace: openshift-gitops
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-gitops"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-gitops"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-gitops"}'
+
+      # Namespace: openshift-pipelines
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-pipelines"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-pipelines"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-pipelines"}'
+
+      # Namespace: openshift-logging
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-logging"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-logging"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-logging"}'
+
+      # Namespace: monitoring (catch-all for monitoring namespaces)
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~".*monitoring.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~".*monitoring.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~".*monitoring.*"}'
+
+      # Namespace: group-sync-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="group-sync-operator"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="group-sync-operator"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="group-sync-operator"}'
+
+      # Namespace: internal-services
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="internal-services"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="internal-services"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="internal-services"}'
+
+      # Namespace: codecov
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="codecov"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="codecov"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="codecov"}'
+
+      # Namespace: tekton-kueue
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="tekton-kueue"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="tekton-kueue"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="tekton-kueue"}'
+
+      # Namespace: openshift-kueue-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-kueue-operator"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-kueue-operator"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-kueue-operator"}'
+
+      # =================================================================
+      # Container Metrics
+      # =================================================================
+      - '{__name__="kube_pod_container_status_waiting_reason", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="kube_pod_container_status_terminated_reason", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="kube_pod_container_status_last_terminated_reason", reason="OOMKilled"}'
+      - '{__name__="kube_pod_container_status_restarts_total", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="container_cpu_usage_seconds_total", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="container_memory_usage_bytes", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="namespace:container_memory_usage_bytes:sum"}'
+      - '{__name__="namespace:container_cpu_usage:sum"}'
+      - '{__name__="namespace_memory:kube_pod_container_resource_requests:sum"}'
+      - '{__name__="namespace_cpu:kube_pod_container_resource_requests:sum"}'
+      - '{__name__="namespace_memory:kube_pod_container_resource_limits:sum"}'
+      - '{__name__="namespace_cpu:kube_pod_container_resource_limits:sum"}'
+      - '{__name__="node_namespace_pod_container:container_memory_working_set_bytes", namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring"}'
+      - '{__name__="kube_pod_container_info", namespace!~"openshift-.*|kube-.*"}'
+
+      # =================================================================
+      # Pod Metrics
+      # =================================================================
+      - '{__name__="kube_pod_status_unschedulable", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="kube_pod_status_phase", namespace!~"openshift-.*|kube-.*"}'
+
+      # =================================================================
+      # Controller Metrics
+      # =================================================================
+      - '{__name__="controller_runtime_reconcile_errors_total", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="controller_runtime_reconcile_total", namespace!~"openshift-.*|kube-.*"}'
+
+      # =================================================================
+      # Kubernetes State Metrics
+      # =================================================================
+      - '{__name__="kube_node_role"}'
+      - '{__name__="kube_node_status_allocatable", resource=~"cpu|memory"}'
+      - '{__name__="kube_node_status_condition", condition="MemoryPressure", status="true"}'
+      - '{__name__="kube_job_spec_completions"}'
+      - '{__name__="kube_job_status_succeeded"}'
+      - '{__name__="kube_job_status_failed"}'
+
+      # =================================================================
+      # Node Metrics
+      # =================================================================
+      - '{__name__="node_cpu_seconds_total", mode="idle"}'
+      - '{__name__="node_memory_MemTotal_bytes"}'
+      - '{__name__="node_memory_MemAvailable_bytes"}'
+
+      # =================================================================
+      # Prometheus Self-Metrics
+      # =================================================================
+      - '{__name__="prometheus_ready"}'
+      - '{__name__="prometheus_engine_query_duration_seconds_count"}'
+      - '{__name__="prometheus_engine_query_duration_seconds"}'
+      - '{__name__="prometheus_tsdb_head_series"}'
+      - '{__name__="prometheus_tsdb_head_chunks"}'
+      - '{__name__="prometheus_target_interval_length_seconds_count"}'
+      - '{__name__="prometheus_target_interval_length_seconds_sum"}'
+      - '{__name__="prometheus_target_scrapes_exceeded_sample_limit_total"}'
+      - '{__name__="prometheus_target_scrapes_sample_duplicate_timestamp_total"}'
+      - '{__name__="prometheus_target_scrapes_sample_out_of_bounds_total"}'
+      - '{__name__="prometheus_target_scrapes_sample_out_of_order_total"}'
+      - '{__name__="prometheus_tsdb_head_samples_appended_total"}'
+      - '{__name__="prometheus_sd_discovered_targets"}'
+      - '{__name__="prometheus_target_sync_length_seconds_sum"}'
+      - '{__name__="prometheus_remote_storage_exemplars_failed_total"}'
+      - '{__name__="prometheus_remote_storage_histograms_failed_total"}'
+      - '{__name__="prometheus_remote_storage_metadata_failed_total"}'
+      - '{__name__="prometheus_remote_storage_samples_failed_total"}'
+      - '{__name__="promhttp_metric_handler_requests_total"}'
+      - '{__name__="promhttp_metric_handler_requests_in_flight"}'
+      - '{__name__="prometheus_tsdb_head_chunks_storage_size_bytes"}'
+      - '{__name__="prometheus_tsdb_storage_blocks_bytes"}'
+      - '{__name__="prometheus_tsdb_wal_storage_size_bytes"}'
+      - '{__name__="prometheus_tsdb_wal_writes_failed_total"}'
+      - '{__name__="prometheus_tsdb_wal_truncations_failed_total"}'
+      - '{__name__="prometheus_tsdb_reloads_failures_total"}'
+      - '{__name__="prometheus_tsdb_head_truncations_failed_total"}'
+      - '{__name__="prometheus_tsdb_compactions_failed_total"}'
+      - '{__name__="prometheus_tsdb_checkpoint_deletions_failed_total"}'
+      - '{__name__="prometheus_tsdb_checkpoint_creations_failed_total"}'
+      - '{__name__="prometheus_build_info"}'
+      - '{__name__="process_start_time_seconds"}'
+
+    relabelings:
+    - action: replace
+      targetLabel: __address__
+      replacement: prometheus-k8s.openshift-monitoring.svc:9091
+    - action: labeldrop
+      regex: pod|namespace|service|endpoint|container
+    interval: 30s
+    honorLabels: true
+    port: web
+    scheme: https
+    path: "/federate"
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      serverName: prometheus-k8s.openshift-monitoring.svc
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: openshift-service-ca.crt

--- a/components/monitoring/prometheus/external-staging/federation-uwm-smon.yaml
+++ b/components/monitoring/prometheus/external-staging/federation-uwm-smon.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: appstudio-federate-uwm-smon
+  namespace: appstudio-monitoring
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: observability-operator
+      app.kubernetes.io/name: appstudio-federate-ms-prometheus
+  endpoints:
+  - params:
+      'match[]':
+        - '{__name__=~".*"}'
+    relabelings:
+    - action: replace
+      targetLabel: __address__
+      replacement: prometheus-user-workload.openshift-user-workload-monitoring.svc:9092
+    - action: labeldrop
+      regex: pod|namespace|service|endpoint|container
+    interval: 30s
+    honorLabels: true
+    port: web
+    scheme: https
+    path: "/federate"
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      serverName: prometheus-user-workload.openshift-user-workload-monitoring.svc
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: openshift-service-ca.crt

--- a/components/monitoring/prometheus/external-staging/kustomization.yaml
+++ b/components/monitoring/prometheus/external-staging/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - observability-operator.yaml
+  - monitoringstack.yaml
+  - federation-smon.yaml
+  - federation-uwm-smon.yaml
+  - federation-rbac.yaml
+  - rhobs-external-secret.yaml
+  - rbac-monitoring-admin.yaml
+  - rbac-monitoring-all-admin.yaml
+  - uwm-config.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/prometheus/external-staging/monitoringstack.yaml
+++ b/components/monitoring/prometheus/external-staging/monitoringstack.yaml
@@ -1,0 +1,54 @@
+apiVersion: monitoring.rhobs/v1alpha1
+kind: MonitoringStack
+metadata:
+  name: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  resourceSelector:
+    matchLabels:
+      monitoring.rhobs/stack: appstudio-federate-ms
+  logLevel: debug
+  retention: 3h
+  alertmanagerConfig:
+    disabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 2Gi
+    limits:
+      memory: 2Gi
+  prometheusConfig:
+    externalLabels:
+      source_environment: staging
+      source_cluster: kflux-c-stg-e01
+    replicas: 1
+    remoteWrite:
+    - oauth2:
+        clientId:
+          secret:
+            key: client-id
+            name: rhobs
+        clientSecret:
+          key: client-secret
+          name: rhobs
+        endpointParams:
+          audience: observatorium-osd-staging
+        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+      url: https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhtap/api/v1/receive
+      writeRelabelConfigs:
+      - action: LabelKeep
+        regex: "__name__|source_environment|source_cluster|namespace|app|pod|container|\
+          label_pipelines_appstudio_openshift_io_type|health_status|dest_namespace|\
+          controller|service|reason|phase|type|resource|resourcequota|le|image|\
+          commit_hash|job|operation|tokenName|rateLimited|state|persistentvolumeclaim|\
+          storageclass|volumename|release_reason|instance|result|deployment_reason|\
+          validation_reason|strategy|succeeded|target|name|method|code|sp|\
+          unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status|\
+          pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code|\
+          grpc_method|lease|lease_holder|deployment|platform|mode|cpu|role|node|kind|\
+          verb|request_kind|tested_cluster|resource_type|exported_job|http_method|\
+          http_route|http_status_code|gin_errors|rule_result|rule_execution_cause|\
+          policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
+          resource_request_operation|resource_kind|policy_change_type|event_type|\
+          cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
+          priority_class|severity"

--- a/components/monitoring/prometheus/external-staging/namespace.yaml
+++ b/components/monitoring/prometheus/external-staging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-monitoring

--- a/components/monitoring/prometheus/external-staging/observability-operator.yaml
+++ b/components/monitoring/prometheus/external-staging/observability-operator.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: appstudio-monitoring
+  namespace: appstudio-monitoring
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: appstudio-monitoring
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      limits:
+        memory: "4Gi"

--- a/components/monitoring/prometheus/external-staging/rbac-monitoring-admin.yaml
+++ b/components/monitoring/prometheus/external-staging/rbac-monitoring-admin.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: all-access-appstudio-monitoring
+  namespace: appstudio-monitoring
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["monitoring.rhobs"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "subscriptions"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: all-access-appstudio-monitoring
+  namespace: appstudio-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-o11y-admins
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-sre
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: all-access-appstudio-monitoring

--- a/components/monitoring/prometheus/external-staging/rbac-monitoring-all-admin.yaml
+++ b/components/monitoring/prometheus/external-staging/rbac-monitoring-all-admin.yaml
@@ -1,0 +1,34 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: o11y-admins-cluster-view
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheusrules
+      - servicemonitors
+      - podmonitors
+      - thanosrulers
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: o11y-admins-cluster-view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-o11y-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-sre
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: o11y-admins-cluster-view

--- a/components/monitoring/prometheus/external-staging/rhobs-external-secret.yaml
+++ b/components/monitoring/prometheus/external-staging/rhobs-external-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rhobs
+  namespace: appstudio-monitoring
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/monitoring/rhobs
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rhobs

--- a/components/monitoring/prometheus/external-staging/uwm-config.yaml
+++ b/components/monitoring/prometheus/external-staging/uwm-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      retention: 3d
+      retentionSize: 10GiB

--- a/components/monitoring/prometheus/internal-production/kustomization.yaml
+++ b/components/monitoring/prometheus/internal-production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Placeholder: full production stack will be added after staging is validated.
+resources:
+  - namespace.yaml

--- a/components/monitoring/prometheus/internal-production/namespace.yaml
+++ b/components/monitoring/prometheus/internal-production/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-monitoring

--- a/components/monitoring/prometheus/internal-staging/federation-rbac.yaml
+++ b/components/monitoring/prometheus/internal-staging/federation-rbac.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appstudio-federate-ms-view
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: appstudio-federate-ms-prometheus
+  namespace: appstudio-monitoring

--- a/components/monitoring/prometheus/internal-staging/federation-smon.yaml
+++ b/components/monitoring/prometheus/internal-staging/federation-smon.yaml
@@ -1,0 +1,217 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: appstudio-federate-smon
+  namespace: appstudio-monitoring
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: observability-operator
+      app.kubernetes.io/name: appstudio-federate-ms-prometheus
+  endpoints:
+  - params:
+      'match[]':
+
+      # =================================================================
+      # Deployment Status (common-cluster namespaces)
+      # =================================================================
+
+      # Namespace: appstudio-monitoring
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="appstudio-monitoring"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="appstudio-monitoring"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="appstudio-monitoring"}'
+
+      # Namespace: argocd-local
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="argocd-local"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="argocd-local"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="argocd-local"}'
+
+      # Namespace: cert-manager / cert-manager-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~"cert-manager.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~"cert-manager.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~"cert-manager.*"}'
+
+      # Namespace: external-secrets-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="external-secrets-operator"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="external-secrets-operator"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="external-secrets-operator"}'
+
+      # Namespace: kargo and kargo-*
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~"kargo.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~"kargo.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~"kargo.*"}'
+
+      # Namespace: konflux-devlake
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-devlake"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-devlake"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-devlake"}'
+
+      # Namespace: konflux-kyverno
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-kyverno"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-kyverno"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-kyverno"}'
+
+      # Namespace: konflux-policies
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-policies"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-policies"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-policies"}'
+
+      # Namespace: konflux-portal-server
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-portal-server"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-portal-server"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="konflux-portal-server"}'
+
+      # Namespace: konflux-support-ops / konflux-support-ops-dashboard
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~"konflux-support-ops.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~"konflux-support-ops.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~"konflux-support-ops.*"}'
+
+      # Namespace: openshift-gitops
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-gitops"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-gitops"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-gitops"}'
+
+      # Namespace: openshift-pipelines
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-pipelines"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-pipelines"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-pipelines"}'
+
+      # Namespace: openshift-logging
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-logging"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-logging"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-logging"}'
+
+      # Namespace: monitoring (catch-all for monitoring namespaces)
+      - '{__name__="kube_deployment_status_replicas_ready", namespace=~".*monitoring.*"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace=~".*monitoring.*"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace=~".*monitoring.*"}'
+
+      # Namespace: group-sync-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="group-sync-operator"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="group-sync-operator"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="group-sync-operator"}'
+
+      # Namespace: internal-services
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="internal-services"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="internal-services"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="internal-services"}'
+
+      # Namespace: codecov
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="codecov"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="codecov"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="codecov"}'
+
+      # Namespace: tekton-kueue
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="tekton-kueue"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="tekton-kueue"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="tekton-kueue"}'
+
+      # Namespace: openshift-kueue-operator
+      - '{__name__="kube_deployment_status_replicas_ready", namespace="openshift-kueue-operator"}'
+      - '{__name__="kube_deployment_status_replicas_available", namespace="openshift-kueue-operator"}'
+      - '{__name__="kube_deployment_spec_replicas", namespace="openshift-kueue-operator"}'
+
+      # =================================================================
+      # Container Metrics
+      # =================================================================
+      - '{__name__="kube_pod_container_status_waiting_reason", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="kube_pod_container_status_terminated_reason", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="kube_pod_container_status_last_terminated_reason", reason="OOMKilled"}'
+      - '{__name__="kube_pod_container_status_restarts_total", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="container_cpu_usage_seconds_total", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="container_memory_usage_bytes", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="namespace:container_memory_usage_bytes:sum"}'
+      - '{__name__="namespace:container_cpu_usage:sum"}'
+      - '{__name__="namespace_memory:kube_pod_container_resource_requests:sum"}'
+      - '{__name__="namespace_cpu:kube_pod_container_resource_requests:sum"}'
+      - '{__name__="namespace_memory:kube_pod_container_resource_limits:sum"}'
+      - '{__name__="namespace_cpu:kube_pod_container_resource_limits:sum"}'
+      - '{__name__="node_namespace_pod_container:container_memory_working_set_bytes", namespace=~"openshift-monitoring|openshift-user-workload-monitoring|appstudio-monitoring"}'
+      - '{__name__="kube_pod_container_info", namespace!~"openshift-.*|kube-.*"}'
+
+      # =================================================================
+      # Pod Metrics
+      # =================================================================
+      - '{__name__="kube_pod_status_unschedulable", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="kube_pod_status_phase", namespace!~"openshift-.*|kube-.*"}'
+
+      # =================================================================
+      # Controller Metrics
+      # =================================================================
+      - '{__name__="controller_runtime_reconcile_errors_total", namespace!~"openshift-.*|kube-.*"}'
+      - '{__name__="controller_runtime_reconcile_total", namespace!~"openshift-.*|kube-.*"}'
+
+      # =================================================================
+      # Kubernetes State Metrics
+      # =================================================================
+      - '{__name__="kube_node_role"}'
+      - '{__name__="kube_node_status_allocatable", resource=~"cpu|memory"}'
+      - '{__name__="kube_node_status_condition", condition="MemoryPressure", status="true"}'
+      - '{__name__="kube_job_spec_completions"}'
+      - '{__name__="kube_job_status_succeeded"}'
+      - '{__name__="kube_job_status_failed"}'
+
+      # =================================================================
+      # Node Metrics
+      # =================================================================
+      - '{__name__="node_cpu_seconds_total", mode="idle"}'
+      - '{__name__="node_memory_MemTotal_bytes"}'
+      - '{__name__="node_memory_MemAvailable_bytes"}'
+
+      # =================================================================
+      # Prometheus Self-Metrics
+      # =================================================================
+      - '{__name__="prometheus_ready"}'
+      - '{__name__="prometheus_engine_query_duration_seconds_count"}'
+      - '{__name__="prometheus_engine_query_duration_seconds"}'
+      - '{__name__="prometheus_tsdb_head_series"}'
+      - '{__name__="prometheus_tsdb_head_chunks"}'
+      - '{__name__="prometheus_target_interval_length_seconds_count"}'
+      - '{__name__="prometheus_target_interval_length_seconds_sum"}'
+      - '{__name__="prometheus_target_scrapes_exceeded_sample_limit_total"}'
+      - '{__name__="prometheus_target_scrapes_sample_duplicate_timestamp_total"}'
+      - '{__name__="prometheus_target_scrapes_sample_out_of_bounds_total"}'
+      - '{__name__="prometheus_target_scrapes_sample_out_of_order_total"}'
+      - '{__name__="prometheus_tsdb_head_samples_appended_total"}'
+      - '{__name__="prometheus_sd_discovered_targets"}'
+      - '{__name__="prometheus_target_sync_length_seconds_sum"}'
+      - '{__name__="prometheus_remote_storage_exemplars_failed_total"}'
+      - '{__name__="prometheus_remote_storage_histograms_failed_total"}'
+      - '{__name__="prometheus_remote_storage_metadata_failed_total"}'
+      - '{__name__="prometheus_remote_storage_samples_failed_total"}'
+      - '{__name__="promhttp_metric_handler_requests_total"}'
+      - '{__name__="promhttp_metric_handler_requests_in_flight"}'
+      - '{__name__="prometheus_tsdb_head_chunks_storage_size_bytes"}'
+      - '{__name__="prometheus_tsdb_storage_blocks_bytes"}'
+      - '{__name__="prometheus_tsdb_wal_storage_size_bytes"}'
+      - '{__name__="prometheus_tsdb_wal_writes_failed_total"}'
+      - '{__name__="prometheus_tsdb_wal_truncations_failed_total"}'
+      - '{__name__="prometheus_tsdb_reloads_failures_total"}'
+      - '{__name__="prometheus_tsdb_head_truncations_failed_total"}'
+      - '{__name__="prometheus_tsdb_compactions_failed_total"}'
+      - '{__name__="prometheus_tsdb_checkpoint_deletions_failed_total"}'
+      - '{__name__="prometheus_tsdb_checkpoint_creations_failed_total"}'
+      - '{__name__="prometheus_build_info"}'
+      - '{__name__="process_start_time_seconds"}'
+
+    relabelings:
+    - action: replace
+      targetLabel: __address__
+      replacement: prometheus-k8s.openshift-monitoring.svc:9091
+    - action: labeldrop
+      regex: pod|namespace|service|endpoint|container
+    interval: 30s
+    honorLabels: true
+    port: web
+    scheme: https
+    path: "/federate"
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      serverName: prometheus-k8s.openshift-monitoring.svc
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: openshift-service-ca.crt

--- a/components/monitoring/prometheus/internal-staging/federation-uwm-smon.yaml
+++ b/components/monitoring/prometheus/internal-staging/federation-uwm-smon.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: appstudio-federate-uwm-smon
+  namespace: appstudio-monitoring
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: observability-operator
+      app.kubernetes.io/name: appstudio-federate-ms-prometheus
+  endpoints:
+  - params:
+      'match[]':
+        - '{__name__=~".*"}'
+    relabelings:
+    - action: replace
+      targetLabel: __address__
+      replacement: prometheus-user-workload.openshift-user-workload-monitoring.svc:9092
+    - action: labeldrop
+      regex: pod|namespace|service|endpoint|container
+    interval: 30s
+    honorLabels: true
+    port: web
+    scheme: https
+    path: "/federate"
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      serverName: prometheus-user-workload.openshift-user-workload-monitoring.svc
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: openshift-service-ca.crt

--- a/components/monitoring/prometheus/internal-staging/kustomization.yaml
+++ b/components/monitoring/prometheus/internal-staging/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - observability-operator.yaml
+  - monitoringstack.yaml
+  - federation-smon.yaml
+  - federation-uwm-smon.yaml
+  - federation-rbac.yaml
+  - rhobs-external-secret.yaml
+  - rbac-monitoring-admin.yaml
+  - rbac-monitoring-all-admin.yaml
+  - uwm-config.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/prometheus/internal-staging/monitoringstack.yaml
+++ b/components/monitoring/prometheus/internal-staging/monitoringstack.yaml
@@ -1,0 +1,54 @@
+apiVersion: monitoring.rhobs/v1alpha1
+kind: MonitoringStack
+metadata:
+  name: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  resourceSelector:
+    matchLabels:
+      monitoring.rhobs/stack: appstudio-federate-ms
+  logLevel: debug
+  retention: 3h
+  alertmanagerConfig:
+    disabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 2Gi
+    limits:
+      memory: 2Gi
+  prometheusConfig:
+    externalLabels:
+      source_environment: staging
+      source_cluster: kflux-c-stg-i01
+    replicas: 1
+    remoteWrite:
+    - oauth2:
+        clientId:
+          secret:
+            key: client-id
+            name: rhobs
+        clientSecret:
+          key: client-secret
+          name: rhobs
+        endpointParams:
+          audience: observatorium-osd-staging
+        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+      url: https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhtap/api/v1/receive
+      writeRelabelConfigs:
+      - action: LabelKeep
+        regex: "__name__|source_environment|source_cluster|namespace|app|pod|container|\
+          label_pipelines_appstudio_openshift_io_type|health_status|dest_namespace|\
+          controller|service|reason|phase|type|resource|resourcequota|le|image|\
+          commit_hash|job|operation|tokenName|rateLimited|state|persistentvolumeclaim|\
+          storageclass|volumename|release_reason|instance|result|deployment_reason|\
+          validation_reason|strategy|succeeded|target|name|method|code|sp|\
+          unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status|\
+          pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code|\
+          grpc_method|lease|lease_holder|deployment|platform|mode|cpu|role|node|kind|\
+          verb|request_kind|tested_cluster|resource_type|exported_job|http_method|\
+          http_route|http_status_code|gin_errors|rule_result|rule_execution_cause|\
+          policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
+          resource_request_operation|resource_kind|policy_change_type|event_type|\
+          cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
+          priority_class|severity"

--- a/components/monitoring/prometheus/internal-staging/namespace.yaml
+++ b/components/monitoring/prometheus/internal-staging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-monitoring

--- a/components/monitoring/prometheus/internal-staging/observability-operator.yaml
+++ b/components/monitoring/prometheus/internal-staging/observability-operator.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: appstudio-monitoring
+  namespace: appstudio-monitoring
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: appstudio-monitoring
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      limits:
+        memory: "4Gi"

--- a/components/monitoring/prometheus/internal-staging/rbac-monitoring-admin.yaml
+++ b/components/monitoring/prometheus/internal-staging/rbac-monitoring-admin.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: all-access-appstudio-monitoring
+  namespace: appstudio-monitoring
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["monitoring.rhobs"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["operators.coreos.com"]
+  resources: ["clusterserviceversions", "subscriptions"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: all-access-appstudio-monitoring
+  namespace: appstudio-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-o11y-admins
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-sre
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: all-access-appstudio-monitoring

--- a/components/monitoring/prometheus/internal-staging/rbac-monitoring-all-admin.yaml
+++ b/components/monitoring/prometheus/internal-staging/rbac-monitoring-all-admin.yaml
@@ -1,0 +1,34 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: o11y-admins-cluster-view
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheusrules
+      - servicemonitors
+      - podmonitors
+      - thanosrulers
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: o11y-admins-cluster-view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-o11y-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-sre
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: o11y-admins-cluster-view

--- a/components/monitoring/prometheus/internal-staging/rhobs-external-secret.yaml
+++ b/components/monitoring/prometheus/internal-staging/rhobs-external-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rhobs
+  namespace: appstudio-monitoring
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/monitoring/rhobs
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rhobs

--- a/components/monitoring/prometheus/internal-staging/uwm-config.yaml
+++ b/components/monitoring/prometheus/internal-staging/uwm-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      retention: 3d
+      retentionSize: 10GiB


### PR DESCRIPTION
Adds a three-tier Prometheus federation setup (Platform Prometheus → OBO MonitoringStack → RHOBS) to the staging common clusters (kflux-c-stg-e01, kflux-c-stg-i01). Federation match[] filters are tailored for common-cluster workloads and exclude control plane metrics unavailable on ROSA HCP. Resources are sized for the low cardinality of ~30 stable service namespaces (1 replica, 2Gi memory).

Each environment directory is fully self-contained with all manifests baked in — no shared base or kustomize inheritance between directories.This follows the direction set by the team architect to avoid base/ directories that create coupling between environments and don't play well with promotion between rings. Promotion to production is an explicit directory copy with environment-specific values adjusted, not implicit kustomize inheritance.

The tradeoff is duplication: 9 of the 10 manifest files are byte-identical between external-staging and internal-staging (the
only difference is source_cluster in monitoringstack.yaml). We accept this cost in exchange for complete environment isolation — changes to one environment directory can never accidentally affect another.

Production directories are placeholders (namespace only) until staging is validated.

Contributes to: [KFLUXINFRA-3829](https://redhat.atlassian.net/browse/KFLUXINFRA-3829)



[KFLUXINFRA-3829]: https://redhat.atlassian.net/browse/KFLUXINFRA-3829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ