### PR TITLE
Deploy blackbox monitoring to all common clusters

### DIFF
--- a/argo-cd-apps/base/all-clusters/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - iam
   - k8s-groups
   - monitoring-workload-grafana
+  - monitoring-workload-blackbox
   - monitoring-workload-logging

--- a/argo-cd-apps/base/all-clusters/monitoring-workload-blackbox/appset.yaml
+++ b/argo-cd-apps/base/all-clusters/monitoring-workload-blackbox/appset.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: monitoring-workload-blackbox
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/monitoring/blackbox
+          environment: ""
+  template:
+    metadata:
+      name: monitoring-workload-blackbox-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: appstudio-monitoring
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/base/all-clusters/monitoring-workload-blackbox/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/monitoring-workload-blackbox/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset.yaml

--- a/components/monitoring/blackbox/external-production/kustomization.yaml
+++ b/components/monitoring/blackbox/external-production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Placeholder: full production blackbox stack will be added after staging is validated.
+resources:
+  - namespace.yaml

--- a/components/monitoring/blackbox/external-production/namespace.yaml
+++ b/components/monitoring/blackbox/external-production/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-monitoring

--- a/components/monitoring/blackbox/external-staging/blackbox-configmap.yaml
+++ b/components/monitoring/blackbox/external-staging/blackbox-configmap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: blackbox-exporter-obo
+  name: blackbox-exporter-obo-config
+  namespace: appstudio-monitoring
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+          method: GET
+          no_follow_redirects: false
+          fail_if_ssl: false
+          fail_if_not_ssl: false
+          preferred_ip_protocol: "ip4"

--- a/components/monitoring/blackbox/external-staging/blackbox-deployment.yaml
+++ b/components/monitoring/blackbox/external-staging/blackbox-deployment.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: blackbox-exporter-obo
+  name: blackbox-exporter-obo
+  namespace: appstudio-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter-obo
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter-obo
+    spec:
+      containers:
+        - name: blackbox-exporter-obo
+          image: quay.io/prometheus/blackbox-exporter:v0.27.0@sha256:a50c4c0eda297baa1678cd4dc4712a67fdea713b832d43ce7fcc5f9bea05094d
+          args:
+            - "--config.file=/etc/blackbox/blackbox.yml"
+          ports:
+            - containerPort: 9115
+              name: http
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/blackbox
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: blackbox-exporter-obo-config

--- a/components/monitoring/blackbox/external-staging/blackbox-service.yaml
+++ b/components/monitoring/blackbox/external-staging/blackbox-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: blackbox-exporter-obo
+  name: blackbox-exporter-obo
+  namespace: appstudio-monitoring
+spec:
+  selector:
+    app: blackbox-exporter-obo
+  ports:
+    - name: http
+      port: 9115
+      targetPort: 9115

--- a/components/monitoring/blackbox/external-staging/github-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/github-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: github-healthz-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "github"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: healthz
+      static:
+        - https://github.com/healthz

--- a/components/monitoring/blackbox/external-staging/kustomization.yaml
+++ b/components/monitoring/blackbox/external-staging/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - blackbox-configmap.yaml
+  - blackbox-deployment.yaml
+  - blackbox-service.yaml
+  - github-probe.yaml
+  - quay-health-probe.yaml
+  - quay-status-probe.yaml
+  - sso-external-probe.yaml
+  - sso-internal-probe.yaml
+  - registry-io-health-probe.yaml
+  - registry-access-health-probe.yaml
+  - vault-probe.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/blackbox/external-staging/quay-health-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/quay-health-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: quay-health-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "quay"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: health
+      static:
+        - https://quay.io/health

--- a/components/monitoring/blackbox/external-staging/quay-status-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/quay-status-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: quay-status-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "quay"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: status
+      static:
+        - https://quay.io/status

--- a/components/monitoring/blackbox/external-staging/registry-access-health-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/registry-access-health-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: registry-access-redhat-health-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "registry-access"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: _health
+      static:
+        - https://registry.access.redhat.com/_health

--- a/components/monitoring/blackbox/external-staging/registry-io-health-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/registry-io-health-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: registry-redhat-io-health-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "registry-io"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: _health
+      static:
+        - https://registry.redhat.io/_health

--- a/components/monitoring/blackbox/external-staging/sso-external-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/sso-external-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: external-sso-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: sso-external
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        target: redhat-external
+      static:
+        - https://sso.redhat.com/auth/realms/redhat-external/

--- a/components/monitoring/blackbox/external-staging/sso-internal-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/sso-internal-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: internal-sso-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: sso-internal
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        target: EmployeeIDP
+      static:
+        - https://auth.redhat.com/auth/realms/EmployeeIDP/

--- a/components/monitoring/blackbox/external-staging/vault-probe.yaml
+++ b/components/monitoring/blackbox/external-staging/vault-probe.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: monitoring.rhobs/v1
+kind: Probe
+metadata:
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  name: vault-external-probe
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "vault-external"
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        target: health
+      static:
+        - https://vault.ci.ext.devshift.net/v1/sys/health?standbyok=true

--- a/components/monitoring/blackbox/internal-production/kustomization.yaml
+++ b/components/monitoring/blackbox/internal-production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Placeholder: full production blackbox stack will be added after staging is validated.
+resources:
+  - namespace.yaml

--- a/components/monitoring/blackbox/internal-production/namespace.yaml
+++ b/components/monitoring/blackbox/internal-production/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-monitoring

--- a/components/monitoring/blackbox/internal-staging/blackbox-configmap.yaml
+++ b/components/monitoring/blackbox/internal-staging/blackbox-configmap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: blackbox-exporter-obo
+  name: blackbox-exporter-obo-config
+  namespace: appstudio-monitoring
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+          method: GET
+          no_follow_redirects: false
+          fail_if_ssl: false
+          fail_if_not_ssl: false
+          preferred_ip_protocol: "ip4"

--- a/components/monitoring/blackbox/internal-staging/blackbox-deployment.yaml
+++ b/components/monitoring/blackbox/internal-staging/blackbox-deployment.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: blackbox-exporter-obo
+  name: blackbox-exporter-obo
+  namespace: appstudio-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter-obo
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter-obo
+    spec:
+      containers:
+        - name: blackbox-exporter-obo
+          image: quay.io/prometheus/blackbox-exporter:v0.27.0@sha256:a50c4c0eda297baa1678cd4dc4712a67fdea713b832d43ce7fcc5f9bea05094d
+          args:
+            - "--config.file=/etc/blackbox/blackbox.yml"
+          ports:
+            - containerPort: 9115
+              name: http
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/blackbox
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: blackbox-exporter-obo-config

--- a/components/monitoring/blackbox/internal-staging/blackbox-service.yaml
+++ b/components/monitoring/blackbox/internal-staging/blackbox-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: blackbox-exporter-obo
+  name: blackbox-exporter-obo
+  namespace: appstudio-monitoring
+spec:
+  selector:
+    app: blackbox-exporter-obo
+  ports:
+    - name: http
+      port: 9115
+      targetPort: 9115

--- a/components/monitoring/blackbox/internal-staging/github-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/github-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: github-healthz-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "github"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: healthz
+      static:
+        - https://github.com/healthz

--- a/components/monitoring/blackbox/internal-staging/kustomization.yaml
+++ b/components/monitoring/blackbox/internal-staging/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - blackbox-configmap.yaml
+  - blackbox-deployment.yaml
+  - blackbox-service.yaml
+  - github-probe.yaml
+  - quay-health-probe.yaml
+  - quay-status-probe.yaml
+  - sso-external-probe.yaml
+  - sso-internal-probe.yaml
+  - registry-io-health-probe.yaml
+  - registry-access-health-probe.yaml
+  - vault-probe.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/blackbox/internal-staging/quay-health-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/quay-health-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: quay-health-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "quay"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: health
+      static:
+        - https://quay.io/health

--- a/components/monitoring/blackbox/internal-staging/quay-status-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/quay-status-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: quay-status-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "quay"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: status
+      static:
+        - https://quay.io/status

--- a/components/monitoring/blackbox/internal-staging/registry-access-health-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/registry-access-health-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: registry-access-redhat-health-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "registry-access"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: _health
+      static:
+        - https://registry.access.redhat.com/_health

--- a/components/monitoring/blackbox/internal-staging/registry-io-health-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/registry-io-health-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: registry-redhat-io-health-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "registry-io"
+  prober:
+    path: /probe
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+    scheme: http
+  module: http_2xx
+  targets:
+    staticConfig:
+      labels:
+        target: _health
+      static:
+        - https://registry.redhat.io/_health

--- a/components/monitoring/blackbox/internal-staging/sso-external-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/sso-external-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: external-sso-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: sso-external
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        target: redhat-external
+      static:
+        - https://sso.redhat.com/auth/realms/redhat-external/

--- a/components/monitoring/blackbox/internal-staging/sso-internal-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/sso-internal-probe.yaml
@@ -1,0 +1,23 @@
+---
+kind: Probe
+apiVersion: monitoring.rhobs/v1
+metadata:
+  name: internal-sso-probe
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: sso-internal
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        target: EmployeeIDP
+      static:
+        - https://auth.redhat.com/auth/realms/EmployeeIDP/

--- a/components/monitoring/blackbox/internal-staging/vault-probe.yaml
+++ b/components/monitoring/blackbox/internal-staging/vault-probe.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: monitoring.rhobs/v1
+kind: Probe
+metadata:
+  labels:
+    kubernetes.io/part-of: appstudio-federate-ms
+    monitoring.rhobs/stack: appstudio-federate-ms
+  name: vault-external-probe
+  namespace: appstudio-monitoring
+spec:
+  interval: 60s
+  jobName: "vault-external"
+  module: http_2xx
+  prober:
+    path: /probe
+    scheme: http
+    url: blackbox-exporter-obo.appstudio-monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      labels:
+        target: health
+      static:
+        - https://vault.ci.ext.devshift.net/v1/sys/health?standbyok=true


### PR DESCRIPTION
Adds a blackbox exporter deployment and Probe CRDs to all four common clusters. The blackbox exporter runs in appstudio-monitoring and probes external service dependencies via HTTP checks:

  - GitHub (/healthz)
  - Quay.io (health + status)
  - Red Hat SSO (external + internal realms)
  - Red Hat container registries (registry.redhat.io + registry.access)
  - Vault (health check)

Probes use the monitoring.rhobs/v1 Probe CRD with the appstudio-federate-ms MonitoringStack label, so probe_success metrics are automatically scraped and remote-written to RHOBS alongside the federation metrics from the Prometheus deployment.

All four environment directories are identical — blackbox probes the same public endpoints regardless of cluster. Each directory is fully self-contained with no shared base or inheritance.

Contributes to: [KFLUXINFRA-3828](https://redhat.atlassian.net/browse/KFLUXINFRA-3828)

[KFLUXINFRA-3828]: https://redhat.atlassian.net/browse/KFLUXINFRA-3828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ