### PR TITLE
Add prometheus_replica to writeRelabelConfigs LabelKeep

### DIFF
--- a/components/monitoring/prometheus/external-production/monitoringstack.yaml
+++ b/components/monitoring/prometheus/external-production/monitoringstack.yaml
@@ -51,4 +51,4 @@ spec:
           policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
           resource_request_operation|resource_kind|policy_change_type|event_type|\
           cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-          priority_class|severity"
+          priority_class|prometheus_replica|severity"

--- a/components/monitoring/prometheus/external-staging/monitoringstack.yaml
+++ b/components/monitoring/prometheus/external-staging/monitoringstack.yaml
@@ -51,4 +51,4 @@ spec:
           policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
           resource_request_operation|resource_kind|policy_change_type|event_type|\
           cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-          priority_class|severity"
+          priority_class|prometheus_replica|severity"

--- a/components/monitoring/prometheus/internal-production/monitoringstack.yaml
+++ b/components/monitoring/prometheus/internal-production/monitoringstack.yaml
@@ -51,4 +51,4 @@ spec:
           policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
           resource_request_operation|resource_kind|policy_change_type|event_type|\
           cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-          priority_class|severity"
+          priority_class|prometheus_replica|severity"

--- a/components/monitoring/prometheus/internal-staging/monitoringstack.yaml
+++ b/components/monitoring/prometheus/internal-staging/monitoringstack.yaml
@@ -51,4 +51,4 @@ spec:
           policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
           resource_request_operation|resource_kind|policy_change_type|event_type|\
           cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-          priority_class|severity"
+          priority_class|prometheus_replica|severity"


### PR DESCRIPTION
Production clusters run 2 Prometheus replicas for HA. Both replicas scrape the same federation targets and remote-write to RHOBS, but the LabelKeep regex was dropping the prometheus_replica label. This made the two replicas' samples indistinguishable to Thanos Receive, causing HTTP 409 Conflict (out of order sample) errors — ~2000 samples rejected per minute.

Adding prometheus_replica to the LabelKeep regex lets both replicas' samples through with a distinguishing label. Thanos Query deduplicates at query time using this label, which is the intended HA pattern.