### PR TITLE
Update rover group sync image digest

### DIFF
--- a/components/rover-group-sync/internal-staging/kustomization.yaml
+++ b/components/rover-group-sync/internal-staging/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: rover-group-sync
 
 images:
 - name: rover-group-sync
-  digest: sha256:a0c5c759213f0a9242da4dfeb7ab7536d7db032ddb96acfe09d4347638173e05
+  digest: sha256:dac15d10a0294dc45e6146547462f135eedf83a334f5aa7f32855a5e4c835e64
 
 resources:
   - ../base


### PR DESCRIPTION
Tested with this job: https://console-openshift-console.apps.rosa.kflux-c-stg-i01.qfla.p3.openshiftapps.com/k8s/ns/rover-group-sync/pods/rover-group-sync-test-1779814000-5gfxr/logs