### PR TITLE
chore: devlake: promote UI to production

### DIFF
--- a/components/konflux-devlake/internal-production/helm-values.yaml
+++ b/components/konflux-devlake/internal-production/helm-values.yaml
@@ -83,7 +83,7 @@ grafana:
 ui:
   image:
     repository: quay.io/konflux-ci/konflux-devprod/devlake-frontend
-    tag: 4f129cfc848e8d0bf18579cf9d727df72d6eb72b
+    tag: ef7bd9ac24729adde5112adcbd5b743a3f8b9087
   securityContext: {}
   containerSecurityContext: {}
   basicAuth:


### PR DESCRIPTION
## Summary

Promotes the DevLake config-ui (frontend) image from staging to production.

| | Tag |
|---|---|
| **Before** | `4f129cfc848e8d0bf18579cf9d727df72d6eb72b` |
| **After** | `ef7bd9ac24729adde5112adcbd5b743a3f8b9087` |

The staging tag corresponds to commit [ef7bd9ac](https://github.com/redhat-appstudio/devlake/commit/ef7bd9ac24729adde5112adcbd5b743a3f8b9087):
> feat(aireview): CI failure prediction with confusion matrix, drill-down, and NO_CI tracking (#68)

This build has been running in internal-staging without issues.

## Test plan
- [ ] Verify UI loads at https://metrics.dprod.io after deployment
- [ ] Check aireview plugin pages render correctly (CI failure prediction, confusion matrix)