### PR TITLE
KFLUXINFRA-3831: Add konflux-admins to Grafana admin RoleBinding

### DIFF
--- a/components/monitoring/grafana/external-production/rbac/grafana-admin.yaml
+++ b/components/monitoring/grafana/external-production/rbac/grafana-admin.yaml
@@ -30,6 +30,9 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: konflux-o11y-admins
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/monitoring/grafana/external-staging/rbac/grafana-admin.yaml
+++ b/components/monitoring/grafana/external-staging/rbac/grafana-admin.yaml
@@ -30,6 +30,9 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: konflux-o11y-admins
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/monitoring/grafana/internal-production/rbac/grafana-admin.yaml
+++ b/components/monitoring/grafana/internal-production/rbac/grafana-admin.yaml
@@ -30,6 +30,9 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: konflux-o11y-admins
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/monitoring/grafana/internal-staging/rbac/grafana-admin.yaml
+++ b/components/monitoring/grafana/internal-staging/rbac/grafana-admin.yaml
@@ -30,6 +30,9 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: konflux-o11y-admins
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
## What
[KFLUXINFRA-3831](https://redhat.atlassian.net/browse/KFLUXINFRA-3831)

Add the `konflux-admins` group to the `all-access-appstudio-grafana` RoleBinding
in all 4 environments (internal-staging, external-staging, internal-production,
external-production).

## Why
The infra team manages these clusters and should have full access to the
Grafana namespace for operational tasks — troubleshooting, managing dashboards,
and handling issues like stuck finalizers on GrafanaDashboard CRs.

Currently only `konflux-o11y-admins` has this access.

## Validation
- PR #396 (Grafana production promotion)
- PR #391 (dashboard grooming)
- PR #369 (Grafana staging)

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR
Adds a group to an existing RoleBinding. No impact on existing access.

[KFLUXINFRA-3831]: https://redhat.atlassian.net/browse/KFLUXINFRA-3831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ