### PR TITLE
Add AGENTS.md and CI lint workflow

### DIFF
--- a/.github/workflows/agents-md-lint.yaml
+++ b/.github/workflows/agents-md-lint.yaml
@@ -1,0 +1,33 @@
+name: Lint AGENTS.md
+
+on:
+  pull_request:
+    paths:
+      - AGENTS.md
+  push:
+    branches: [main]
+    paths:
+      - AGENTS.md
+
+permissions:
+  contents: read
+
+jobs:
+  agents-md-lint:
+    name: Check AGENTS.md line limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate AGENTS.md
+        run: |
+          if [ ! -f AGENTS.md ]; then
+            echo "ERROR: AGENTS.md not found"
+            exit 1
+          fi
+          lines=$(wc -l < AGENTS.md)
+          echo "AGENTS.md has $lines lines (limit: 300)"
+          if [ "$lines" -gt 300 ]; then
+            echo "ERROR: AGENTS.md exceeds 300-line limit"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# infra-common-deployments
+
+GitOps repository for shared infrastructure components across Konflux
+common clusters using ArgoCD (app-of-apps pattern) and Kustomize.
+
+## Quick Commands
+
+| Action         | Command                                                 |
+|----------------|---------------------------------------------------------|
+| Build overlay  | `kustomize build argo-cd-apps/overlays/<env>/`          |
+| Lint YAML      | `yamllint .`                                            |
+| Chainsaw tests | `chainsaw test --config .chainsaw.yaml <test-dir>`      |
+
+Kube-lint (requires building kustomize output first):
+
+```sh
+mkdir -p kustomizedfiles
+kustomize build argo-cd-apps/overlays/<env>/ -o kustomizedfiles/<env>.yaml
+kube-linter lint --config .kube-linter.yaml kustomizedfiles/
+```
+
+Dry-run apply:
+
+```sh
+kustomize build <path> | kubectl apply --dry-run=client -f -
+```
+
+## Project Layout
+
+- `argo-cd-apps/base/{all-clusters,external,internal}/` — ApplicationSet
+  definitions scoped by cluster type.
+- `argo-cd-apps/overlays/` — four environments: `internal-staging`,
+  `internal-production`, `external-staging`, `external-production`.
+- `components/<name>/` — Kustomize components with `base/`, per-env overlays,
+  and optional `k-components/` for shared patches (Component kind `v1alpha1`).
+- `.yamllint.yaml` — relaxed profile, ignores Helm charts/templates.
+- `.kube-linter.yaml` — excludes probe port checks.
+
+## Key Conventions
+
+- App-of-apps pattern: root ArgoCD Application manages ApplicationSets.
+- Kubernetes resource files named after their Kind.
+- Always `kustomize build` all four overlays before submitting changes.
+- yamllint ignores `**/charts/` and `**/templates/` (Helm content).
+- All changes via PR; OWNERS approval required.
+
+## Testing
+
+- Chainsaw tests validate Kyverno policies in `components/kyverno/` and
+  `components/policies/`. Tests live in `.chainsaw-test/` directories.
+- CI creates a Kind cluster, installs Kyverno, then runs chainsaw.
+- kube-linter scans all kustomized output for Kubernetes best practices.
+- yamllint validates all YAML files (relaxed profile, Helm excluded).
+
+## CI Pipeline (GitHub Actions)
+
+- `yamllint` — lints all YAML on PRs and pushes to main.
+- `kube-linter` — builds kustomize overlays, scans with kube-linter,
+  uploads SARIF to GitHub Security tab.
+- `chainsaw-tests` — Kyverno policy tests in Kind. Only triggers on
+  kyverno/policy file changes.
+- `dep-triage` — auto-triages Renovate/Konflux bot dependency PRs.
+- `auto-merge` — merges approved dependency PRs when all checks pass.
+
+## Gotchas
+
+- kube-linter excludes `kargo/` and `konflux-devlake/` (Helm-based).
+- Chainsaw tests require Kyverno fully rolled out (300s timeout).
+- Environment patches target ApplicationSets by group/version/kind —
+  changing ApplicationSet structure may silently break patches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Add agent instructions following the infra team AGENTS.md template: project description, quick commands, layout, conventions, testing, CI pipeline, and gotchas. Add GitHub Actions workflow to enforce the 300-line limit on AGENTS.md changes.

Closes: [KFLUXINFRA-3373](https://redhat.atlassian.net/browse/KFLUXINFRA-3733)



[KFLUXINFRA-3373]: https://redhat.atlassian.net/browse/KFLUXINFRA-3373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ