### PR TITLE
KFLUXINFRA-3834: Deploy kueue and tekton-kueue to internal production

### DIFF
--- a/components/kueue/internal-production/kueue/kueue.yaml
+++ b/components/kueue/internal-production/kueue/kueue.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks: # The operator requires at lest one framework to be enabled
+      - BatchJob
+      externalFrameworks:
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns

--- a/components/kueue/internal-production/kueue/kustomization.yaml
+++ b/components/kueue/internal-production/kueue/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- operator.yaml
+- kueue.yaml
+namespace: openshift-kueue-operator

--- a/components/kueue/internal-production/kueue/operator.yaml
+++ b/components/kueue/internal-production/kueue/operator.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kueue-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  name: redhat-operators-1-18
+  namespace: openshift-kueue-operator
+spec:
+  displayName: redhat-operators-1-18
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kueue-operatorgroup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-kueue-operator
+  namespace: openshift-kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  channel: stable-v1.3
+  installPlanApproval: Automatic
+  name: kueue-operator
+  source: redhat-operators-1-18
+  sourceNamespace: openshift-kueue-operator

--- a/components/kueue/internal-production/kustomization.yaml
+++ b/components/kueue/internal-production/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue
+- localqueues
+- tekton-kueue
+- queue-config
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue/internal-production/localqueues/internal-services.yaml
+++ b/components/kueue/internal-production/localqueues/internal-services.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: internal-services
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterQueue: cluster-pipeline-queue

--- a/components/kueue/internal-production/localqueues/kustomization.yaml
+++ b/components/kueue/internal-production/localqueues/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- internal-services.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "11"
+
+# namespace: DO NOT USE THIS FIELD, this allows us to create localqueues for components in more than one namespace

--- a/components/kueue/internal-production/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-production/queue-config/cluster-queue.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-pipeline-queue
+spec:
+  namespaceSelector: {}
+  queueingStrategy: BestEffortFIFO
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - signing-server-request
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '500'
+      - name: signing-server-request
+        nominalQuota: '500'
+  stopPolicy: None

--- a/components/kueue/internal-production/queue-config/kustomization.yaml
+++ b/components/kueue/internal-production/queue-config/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- workload-priority-class.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/components/kueue/internal-production/queue-config/workload-priority-class.yaml
+++ b/components/kueue/internal-production/queue-config/workload-priority-class.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-default
+value: 400
+description: "Default priority for pipelines"

--- a/components/kueue/internal-production/tekton-kueue/config.yaml
+++ b/components/kueue/internal-production/tekton-kueue/config.yaml
@@ -1,0 +1,13 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    - |
+        priority('konflux-default')
+
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/rate-limited' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limited'] == 'true' &&
+        'internal-services.appstudio.openshift.io/rate-limiting-group' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['internal-services.appstudio.openshift.io/rate-limiting-group'] == 'signing-server' ?
+        [resource('signing-server-request', 1)] : []

--- a/components/kueue/internal-production/tekton-kueue/controller-patch.yaml
+++ b/components/kueue/internal-production/tekton-kueue/controller-patch.yaml
@@ -1,0 +1,49 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 2
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 500m
+    memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 500m
+    memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue/internal-production/tekton-kueue/kustomization.yaml
+++ b/components/kueue/internal-production/tekton-kueue/kustomization.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=815dbf158b0e39df568eb901dcf05e759099991a
+
+images:
+- name: konflux-ci/tekton-kueue
+  newName: quay.io/konflux-ci/tekton-kueue
+  newTag: 815dbf158b0e39df568eb901dcf05e759099991a
+
+namespace: tekton-kueue
+
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"
+
+configMapGenerator:
+- name: tekton-kueue-config
+  namespace: tekton-kueue
+  behavior: replace
+  files:
+  - config.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+- path: controller-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-controller-manager
+    version: v1
+- path: webhook-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-webhook
+    version: v1
+- target:
+    kind: Namespace
+    name: tekton-kueue
+  patch: |-
+    - op: add
+      path: /metadata/labels/openshift.io~1cluster-monitoring
+      value: "true"

--- a/components/kueue/internal-production/tekton-kueue/webhook-patch.yaml
+++ b/components/kueue/internal-production/tekton-kueue/webhook-patch.yaml
@@ -1,0 +1,41 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 3
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue-webhook
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 200m
+    memory: 256Mi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 200m
+    memory: 256Mi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --zap-log-level=5


### PR DESCRIPTION
## What
[KFLUXINFRA-3834](https://redhat.atlassian.net/browse/KFLUXINFRA-3834)

Promote the validated kueue and tekton-kueue deployment from internal staging
to internal production clusters.

The `internal-production` directory is a self-contained copy of `internal-staging`:
- **Kueue operator** (`kueue/`): OLM-managed installation via `stable-v1.3` channel from `redhat-operators-1-18` catalog, with a `Kueue` CR enabling BatchJob and Tekton PipelineRun frameworks
- **tekton-kueue** (`tekton-kueue/`): Controller (2 replicas) + webhook (3 replicas) from [konflux-ci/tekton-kueue](https://github.com/konflux-ci/tekton-kueue) with CEL-based queue assignment and signing-server rate limiting
- **Queue configuration** (`queue-config/`): ClusterQueue (`cluster-pipeline-queue`, 500 pipelineruns quota), ResourceFlavor, and WorkloadPriorityClass (`konflux-default` at 400)
- **Local queues** (`localqueues/`): LocalQueue (`pipelines-queue`) in `internal-services` namespace

No ArgoCD changes needed — the existing ApplicationSet already resolves `internal-production` via the environment patch.

## Why
Kueue has been running successfully on internal staging since PR #324 (initial deployment)
and PR #342 (v1.3 upgrade). Signing PipelineRuns need to be queued and throttled on production
to protect the signing server from getting overwhelmed, matching the staging behavior.

## Scope
- **Staging PRs**: #324 (initial deploy), #334 (signing priority + CEL), #337 (signing-server resource quota), #340 (FIFO simplification), #342 (v1.3 upgrade), #344 (teardown for upgrade)
- **This PR**: Internal production — exact copy of staging

## Validation
- `kustomize build components/kueue/internal-production/` passes and produces correct manifests
- `diff -r internal-staging/ internal-production/` shows no differences
- ArgoCD sync waves ensure correct ordering: Namespace → CatalogSource → OperatorGroup → Subscription → Kueue CR (waves -4 to 1) → tekton-kueue + queue-config (wave 10) → localqueues (wave 11)

## Risk Assessment
**Risk Level:** Low

Production deployment of a component already validated on staging. Additive change deploying
new components to dedicated namespaces (`openshift-kueue-operator`, `tekton-kueue`). Does not
modify any existing components. ArgoCD automated sync with prune and self-heal is enabled.
**Rollback:** Revert PR — ArgoCD will prune all kueue resources.

[KFLUXINFRA-3834]: https://redhat.atlassian.net/browse/KFLUXINFRA-3834