### PR TITLE
KFLUXINFRA-3862: Upgrade CLO subscription channel to stable-6.3 in staging

### DIFF
--- a/components/monitoring/logging/external-staging/kustomization.yaml
+++ b/components/monitoring/logging/external-staging/kustomization.yaml
@@ -29,3 +29,12 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: cluster-logging
+    patch: |-
+      - op: replace
+        path: /spec/channel
+        value: "stable-6.3"

--- a/components/monitoring/logging/internal-staging/kustomization.yaml
+++ b/components/monitoring/logging/internal-staging/kustomization.yaml
@@ -29,3 +29,12 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: cluster-logging
+    patch: |-
+      - op: replace
+        path: /spec/channel
+        value: "stable-6.3"


### PR DESCRIPTION
**Summary**
  
The CLO v6.1.8 (channel stable-6.1) has a max supported OCP version of 4.18, blocking the OCP 4.19 upgrade on kflux-c-stg-e01 and kflux-c-stg-i01.

CLO supports N+2 channel jumps, so the upgrade path is:
1. **This MR** — stable-6.1 → stable-6.3
2. Follow-up MR — stable-6.3 → stable-6.4
  
**Changes**

Added a kustomize patch to override the Subscription channel in:

- `external-staging/kustomization.yaml` (kflux-c-stg-e01)
- `internal-staging/kustomization.yaml` (kflux-c-stg-i01)

Base is left at stable-6.1 to avoid affecting production clusters.

**Validation**

- [ ] CLO 6.3 installs successfully on both staging clusters
- [ ] Logs from both clusters still reach Splunk
- [ ] No degraded ClusterOperator conditions

**Related**

- Jira: https://redhat.atlassian.net/browse/KFLUXINFRA-3862
- Blocked upgrade: https://redhat.atlassian.net/browse/KFLUXINFRA-3225
