### PR TITLE
kueue: cut resources to zero

### DIFF
--- a/components/kueue/internal-staging/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-staging/queue-config/cluster-queue.yaml
@@ -24,7 +24,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '500'
+        nominalQuota: '0'
       - name: signing-server-request
-        nominalQuota: '500'
+        nominalQuota: '0'
   stopPolicy: None


### PR DESCRIPTION
Signing server is overloaded, shed load until it recovers.