### PR TITLE
KFLUXSPRT-8002: Scale support-ops to zero replicas in internal staging

### DIFF
--- a/components/konflux-support-ops/internal-staging/kustomization.yaml
+++ b/components/konflux-support-ops/internal-staging/kustomization.yaml
@@ -6,3 +6,15 @@ namespace: konflux-support-ops
 resources:
 - ../base
 - external-secrets
+
+patches:
+- target:
+    kind: Deployment
+    name: support-ops
+  patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: support-ops
+    spec:
+      replicas: 0


### PR DESCRIPTION
Disable the support-ops deployment in internal staging until it is ready to run there.