### PR TITLE
revert kueue block in stg internal requests

### DIFF
--- a/components/kueue/internal-staging/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-staging/queue-config/cluster-queue.yaml
@@ -24,7 +24,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '0'
+        nominalQuota: '300'
       - name: signing-server-request
-        nominalQuota: '0'
+        nominalQuota: '300'
   stopPolicy: None


### PR DESCRIPTION
- Revert the change in kueue to allow internal request traffic in internal stg common. 
- Increased to 300 to reduce internal requests rate for now.