### PR TITLE
[KFLUXINFRA-3862] Upgrade CLO subscription channel to stable-6.4 in staging

### DIFF
--- a/components/monitoring/logging/external-staging/kustomization.yaml
+++ b/components/monitoring/logging/external-staging/kustomization.yaml
@@ -37,4 +37,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/channel
-        value: "stable-6.3"
+        value: "stable-6.4"

--- a/components/monitoring/logging/internal-staging/kustomization.yaml
+++ b/components/monitoring/logging/internal-staging/kustomization.yaml
@@ -37,4 +37,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/channel
-        value: "stable-6.3"
+        value: "stable-6.4"


### PR DESCRIPTION
[KFLUXINFRA-3862](https://redhat.atlassian.net/browse/KFLUXINFRA-3862): Upgrade CLO to stable-6.4 in staging (step 2/2)

**Summary**
  
Step 2 of the CLO upgrade: stable-6.3 → stable-6.4.
  
Step 1 (stable-6.1 → stable-6.3) was completed in [#401](https://github.com/redhat-appstudio/infra-common-deployments/pull/401) and verified via [ArgoCD — Subscription synced and healthy on both clusters](https://argocd-server-argocd-local.apps.rosa.kflux-c-stg-e01.3zdg.p3.openshiftapps.com/applications/argocd-local/monitoring-workload-logging-in-cluster?resource=).

**Changes**
  
Updated the channel patch from `stable-6.3` to `stable-6.4` in:

- `external-staging/kustomization.yaml` (kflux-c-stg-e01)
- `internal-staging/kustomization.yaml` (kflux-c-stg-i01)

  
**Validation**
  

- [ ] CLO 6.4 installs successfully on both staging clusters
- [ ] Logs from both clusters still reach Splunk
- [ ] OCP 4.19 upgrade is no longer blocked by IncompatibleOperatorsInstalled

**Related**
  

- Jira: https://redhat.atlassian.net/browse/KFLUXINFRA-3862
- Step 1 PR: https://github.com/redhat-appstudio/infra-common-deployments/pull/401


[KFLUXINFRA-3862]: https://redhat.atlassian.net/browse/KFLUXINFRA-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ