### PR TITLE
install cert-mananger in internal-production

### DIFF
--- a/components/cert-manager/internal-production/kustomization.yaml
+++ b/components/cert-manager/internal-production/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
it is needed to rollout kueue

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
