### PR TITLE
bump tekton-kueue to latest revision in stg

### DIFF
--- a/components/kueue/internal-staging/tekton-kueue/kustomization.yaml
+++ b/components/kueue/internal-staging/tekton-kueue/kustomization.yaml
@@ -2,12 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/tekton-kueue/config/default?ref=815dbf158b0e39df568eb901dcf05e759099991a
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=f6ea94781e283709dbbf33a626f6be4b96a61c85
 
 images:
 - name: konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 815dbf158b0e39df568eb901dcf05e759099991a
+  newTag: f6ea94781e283709dbbf33a626f6be4b96a61c85
 
 namespace: tekton-kueue
 


### PR DESCRIPTION
**kustomize build diffs**

```diff
407c407
<         image: quay.io/konflux-ci/tekton-kueue:f6ea94781e283709dbbf33a626f6be4b96a61c85
---
>         image: quay.io/konflux-ci/tekton-kueue:815dbf158b0e39df568eb901dcf05e759099991a
509c509
<         image: quay.io/konflux-ci/tekton-kueue:f6ea94781e283709dbbf33a626f6be4b96a61c85
---
>         image: quay.io/konflux-ci/tekton-kueue:815dbf158b0e39df568eb901dcf05e759099991a
649c649
< apiVersion: kueue.x-k8s.io/v1beta2
---
> apiVersion: kueue.x-k8s.io/v1beta1
```

Signed-off-by: Francesco Ilario <filario@redhat.com>
