### PR TITLE
increase memory for Internal-Request's CronJob

### DIFF
--- a/components/internal-services/internal-production/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/components/internal-services/internal-production/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -76,10 +76,10 @@ spec:
               resources:
                 limits:
                   cpu: 200m
-                  memory: 256Mi
+                  memory: 512Mi
                 requests:
                   cpu: 200m
-                  memory: 256Mi
+                  memory: 512Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/components/internal-services/internal-staging/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/components/internal-services/internal-staging/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -76,10 +76,10 @@ spec:
               resources:
                 limits:
                   cpu: 200m
-                  memory: 256Mi
+                  memory: 512Mi
                 requests:
                   cpu: 200m
-                  memory: 256Mi
+                  memory: 512Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
we noticed some OOMKilled in production.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
