### PR TITLE
Enable the konflux-devprod group to manage ProjectConfigs

### DIFF
--- a/components/kargo/internal-staging/deployment/rbac/konflux-devprod-projectconfigs.yaml
+++ b/components/kargo/internal-staging/deployment/rbac/konflux-devprod-projectconfigs.yaml
@@ -1,0 +1,31 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-kargo-projectconfigs
+rules:
+  - apiGroups:
+      - kargo.akuity.io
+    resources:
+      - projectconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-devprod-kargo-projectconfigs
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-devprod-kargo-projectconfigs

--- a/components/kargo/internal-staging/deployment/rbac/kustomization.yaml
+++ b/components/kargo/internal-staging/deployment/rbac/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 
 resources:
 - konflux-devprod-admins.yaml
+- konflux-devprod-projectconfigs.yaml


### PR DESCRIPTION
The DevProd team should be able to create and manage ProjectConfigs for the projects onboarded into Kargo.