### PR TITLE
chore(devlake): update frontend image

### DIFF
--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -94,7 +94,7 @@ grafana:
 ui:
   image:
     repository: quay.io/konflux-ci/konflux-devprod/devlake-frontend
-    tag: ef7bd9ac24729adde5112adcbd5b743a3f8b9087
+    tag: 6ac917b4eb1f0513dca71687ee4ec579ca484943
   securityContext: {}
   containerSecurityContext: {}
   basicAuth:


### PR DESCRIPTION
This should allow the agentready plugin to show up in the project settings page.

Related commit: https://github.com/konflux-ci/devlake/commit/6ac917b4eb1f0513dca71687ee4ec579ca484943