### PR TITLE
chore(devlake): update helm chart URL

### DIFF
--- a/components/konflux-devlake/internal-staging/kustomization.yaml
+++ b/components/konflux-devlake/internal-staging/kustomization.yaml
@@ -16,7 +16,7 @@ patches:
 
 helmCharts:
 - name: devlake
-  repo: https://apache.github.io/incubator-devlake-helm-chart
+  repo: https://apache.github.io/devlake-helm-chart
   version: 1.0.2
   releaseName: konflux-devlake
   namespace: konflux-devlake


### PR DESCRIPTION
old (404):
https://apache.github.io/incubator-devlake-helm-chart/index.yaml

new: https://apache.github.io/devlake-helm-chart/index.yaml