### PR TITLE
fix(RELEASE-2170): put signing configmaps back

### DIFF
--- a/components/internal-services/internal-staging/kustomization.yaml
+++ b/components/internal-services/internal-staging/kustomization.yaml
@@ -24,3 +24,6 @@ resources:
 
   # External Secrets
   - es/
+
+  # Signing configurations
+  - signing/

--- a/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-openshifthosted.yaml
+++ b/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-openshifthosted.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-openshifthosted"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+  UMB_BATCH_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.konflux.sign
+  UMB_BATCH_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.konflux.sign
+  SIGNER_TYPE: "batch"

--- a/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-redhatbeta2.yaml
+++ b/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-redhatbeta2.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatbeta2"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+  UMB_BATCH_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.konflux.sign
+  UMB_BATCH_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.konflux.sign
+  SIGNER_TYPE: "batch"

--- a/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-redhatrelease2.yaml
+++ b/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-redhatrelease2.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatrelease2"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+  UMB_BATCH_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.konflux.sign
+  UMB_BATCH_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.konflux.sign
+  SIGNER_TYPE: "batch"

--- a/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-staging-e2e-pq.yaml
+++ b/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-staging-e2e-pq.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-e2e-pq"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_NAMES: "redhate2etesting redhate2etestingpq"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+  UMB_BATCH_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.konflux.sign
+  UMB_BATCH_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.konflux.sign
+  SIGNER_TYPE: "batch"

--- a/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-staging-e2e.yaml
+++ b/components/internal-services/internal-staging/signing/hacbs-signing-pipeline-config-staging-e2e.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-e2e"
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_NAMES: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+  UMB_BATCH_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.konflux.sign
+  UMB_BATCH_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.konflux.sign
+  SIGNER_TYPE: "batch"

--- a/components/internal-services/internal-staging/signing/kustomization.yaml
+++ b/components/internal-services/internal-staging/signing/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - hacbs-signing-pipeline-config-openshifthosted.yaml
+  - hacbs-signing-pipeline-config-redhatbeta2.yaml
+  - hacbs-signing-pipeline-config-redhatrelease2.yaml
+  - hacbs-signing-pipeline-config-staging-e2e.yaml
+  - hacbs-signing-pipeline-config-staging-e2e-pq.yaml


### PR DESCRIPTION
It turns out the internal create-advisory-task is reading these, I missed that.

Revert "chore([RELEASE-2170](https://redhat.atlassian.net/browse/RELEASE-2170)): remove signing configmaps in stage (#423)"

This reverts commit 31d4e199f56e9941983c90ee3cbe7de5dbc6cf80.

[RELEASE-2170]: https://redhat.atlassian.net/browse/RELEASE-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ