### PR TITLE
Increase CPU and PIPELINE_MAX_PARALLEL values

### DIFF
--- a/components/konflux-devlake/internal-production/helm-values.yaml
+++ b/components/konflux-devlake/internal-production/helm-values.yaml
@@ -12,7 +12,7 @@ lake:
   containerSecurityContext: {}
   resources:
     requests:
-      cpu: "2"
+      cpu: "4"
       memory: "4Gi"
     limits:
       memory: "8Gi"
@@ -22,7 +22,7 @@ lake:
     LOGGING_DIR: "/tmp"
     LOGGING_LEVEL: "info"
     IN_SECURE_SKIP_VERIFY: "true"
-    PIPELINE_MAX_PARALLEL: "35"
+    PIPELINE_MAX_PARALLEL: "50"
     CORS_ALLOW_ORIGIN: "https://metrics.dprod.io,https://konflux-devlake-ui-konflux-devlake.apps.rosa.kflux-c-prd-i01.7hyu.p3.openshiftapps.com"
 
     # API timeout - increase for large repositories with slow responses


### PR DESCRIPTION
  - Bump PIPELINE_MAX_PARALLEL from 35 to 50 to reduce pipeline queue backlog
  - Increase CPU request from 2 to 4 cores to support higher concurrency
  - Current usage shows ~1 GiB / 8 GiB memory and ~1 CPU core, plenty of headroom
  - Confirmed with @flacatus that resources can handle this