### PR TITLE
Disable Jira subtasks to reduce pipeline run time

### DIFF
--- a/components/konflux-devlake/internal-production/helm-values.yaml
+++ b/components/konflux-devlake/internal-production/helm-values.yaml
@@ -28,6 +28,12 @@ lake:
     # API timeout - increase for large repositories with slow responses
     API_TIMEOUT: "240s"
 
+    # =========================================================
+    # Disable Jira subtasks that generate excessive temp files to reduce pipeline run time and ephemeral storage usaage
+    # These write to domain tables (sprint_issues, accounts, issue_relationships) not used by Issue Cycle Time dashboards.
+    # =========================================================
+    ENABLE_SUBTASKS_BY_DEFAULT: "jira:convertSprintIssues:false,jira:convertAccounts:false,jira:convertIssueRelationships:false,jira:collectParentIssues:false"
+
     # API retry attempts for transient failures
     API_RETRY: "5"
 


### PR DESCRIPTION
Added configuration to disable Jira subtasks for efficiency.  Jira tasks are stuck at subtask 11/38
Add ENABLE_SUBTASKS_BY_DEFAULT to disable 4 Jira subtasks:
  - convertSprintIssues (writes to sprint_issues table)
  - convertAccounts (writes to accounts table)
  - convertIssueRelationships 
  - collectParentIssues 
