### PR TITLE
feat: update kargo to use Konflux build images

### DIFF
--- a/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
+++ b/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
@@ -8,6 +8,9 @@ version: 1.10.3
 namespace: kargo
 releaseName: kargo
 valuesInline:
+  image:
+    repository: quay.io/konflux-ci/kargo
+    tag: "65cb390"
   api:
     adminAccount:
       enabled: false
@@ -29,6 +32,9 @@ valuesInline:
           - konflux-devprod
       dex:
         enabled: true
+        image:
+          repository: quay.io/konflux-ci/dex
+          tag: 0e579a6bc47dd7d7c9fe128e2428a13fb4d4a64a
         skipApprovalScreen: true
         tls:
           selfSignedCert: false


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Switch Kargo Helm generator to Konflux-built Kargo and Dex images
<code>✨ Enhancement</code> <code>⚙️ Configuration changes</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Override Kargo image to pull from Konflux (quay.io/konflux-ci/kargo).
• Override Dex image to pull from Konflux (quay.io/konflux-ci/dex).
• Pin Dex to a specific tag while keeping Kargo on the 1.10 tag line.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["kargo-helm-generator.yaml"] --> B(["Kargo deployment"]) --> E{{"quay.io"}}
  A --> C(["Dex deployment"]) --> E
  subgraph Legend
    direction LR
    _file["Config file"] ~~~ _svc(["Workload"]) ~~~ _ext{{"External registry"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Pin images by digest (immutable references)</b></summary>

- ➕ Stronger reproducibility (exact bytes) across environments
- ➕ Better supply-chain security posture; avoids tag mutation risk
- ➖ Requires digest management/automation to keep images updated
- ➖ Less human-readable than semantic tags

</details>

<details>
<summary><b>2. Centralize image overrides via global chart values</b></summary>

- ➕ Reduces per-component duplication if multiple charts need the same registry switch
- ➕ Simplifies future registry migrations
- ➖ Depends on chart support for global image settings; may require chart changes
- ➖ Can obscure which subcomponent images are being overridden

</details>

**Recommendation:** Current approach is appropriate for a targeted internal-staging change: it is explicit and minimally invasive. If reproducibility/supply-chain constraints are strict, consider moving Kargo (like Dex) to an immutable digest pin rather than a floating minor tag.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>kargo-helm-generator.yaml</strong> <code>Override Kargo and Dex images to Konflux repositories</code> <code>+6/-0</code></summary>

<br/>

>Override Kargo and Dex images to Konflux repositories
>
><pre>
>• Adds Helm values overrides to pull Kargo from quay.io/konflux-ci/kargo with tag &quot;1.10&quot;. Also configures Dex to pull from quay.io/konflux-ci/dex with a pinned tag value.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/434/files#diff-5d0ae652c4dffadb421bcb2dc9e9071f5a5187f2a59bdc27f3062458a92e0e66'>components/kargo/internal-staging/deployment/kargo-helm-generator.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>