### PR TITLE
Remove metrics.dprod.io from CORS and enable FORCE_FULL_GIT_HISTORY on staging

### DIFF
--- a/components/konflux-devlake/internal-production/helm-values.yaml
+++ b/components/konflux-devlake/internal-production/helm-values.yaml
@@ -23,7 +23,7 @@ lake:
     LOGGING_LEVEL: "info"
     IN_SECURE_SKIP_VERIFY: "true"
     PIPELINE_MAX_PARALLEL: "10"
-    CORS_ALLOW_ORIGIN: "https://metrics.dprod.io,https://konflux-devlake-ui-konflux-devlake.apps.rosa.kflux-c-prd-i01.7hyu.p3.openshiftapps.com"
+    CORS_ALLOW_ORIGIN: "https://konflux-devlake-ui-konflux-devlake.apps.rosa.kflux-c-prd-i01.7hyu.p3.openshiftapps.com"
 
     # API timeout - increase for large repositories with slow responses
     API_TIMEOUT: "240s"

--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -25,6 +25,12 @@ lake:
     PIPELINE_MAX_PARALLEL: "4"
     CORS_ALLOW_ORIGIN: "https://konflux-devlake-ui-konflux-devlake.apps.rosa.kflux-c-stg-i01.qfla.p3.openshiftapps.com"
 
+    # Force full git clone on every run, including incremental syncs.
+    # Fixes missing commits caused by --shallow-since edge cases where
+    # upstream gitextractor skips commits during incremental collection.
+    # Uses more disk and memory but ensures complete git history.
+    FORCE_FULL_GIT_HISTORY: "true"
+
     # API timeout - increase for large repositories with slow responses
     API_TIMEOUT: "180s"
 

--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -23,7 +23,7 @@ lake:
     LOGGING_LEVEL: "info"
     IN_SECURE_SKIP_VERIFY: "true"
     PIPELINE_MAX_PARALLEL: "4"
-    CORS_ALLOW_ORIGIN: "https://metrics.dprod.io,https://konflux-devlake-ui-konflux-devlake.apps.rosa.kflux-c-stg-i01.qfla.p3.openshiftapps.com"
+    CORS_ALLOW_ORIGIN: "https://konflux-devlake-ui-konflux-devlake.apps.rosa.kflux-c-stg-i01.qfla.p3.openshiftapps.com"
 
     # API timeout - increase for large repositories with slow responses
     API_TIMEOUT: "180s"


### PR DESCRIPTION
## Summary
- Remove `metrics.dprod.io` from `CORS_ALLOW_ORIGIN` in both staging and production. The dashboard calls n8n webhooks server-side, not the DevLake API from the browser, so no CORS entry for the dashboard origin is needed.
- Enable `FORCE_FULL_GIT_HISTORY` on staging to fix missing commits caused by `--shallow-since` edge cases in the upstream gitextractor.

Ref: [DPROD-1298](https://redhat.atlassian.net/browse/DPROD-1298)

## Test plan
- [ ] Verify staging DevLake config UI still loads and can reach the backend API
- [ ] Verify production DevLake config UI still loads after CORS change
- [ ] Confirm staging git collection includes complete commit history after next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DPROD-1298]: https://redhat.atlassian.net/browse/DPROD-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ