### PR TITLE
[KFLUXINFRA-3863] Upgrade ClusterLoggingOperator to 6.3 in production clusters

### DIFF
--- a/components/monitoring/logging/external-production/kustomization.yaml
+++ b/components/monitoring/logging/external-production/kustomization.yaml
@@ -29,3 +29,12 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: cluster-logging
+    patch: |-
+      - op: replace
+        path: /spec/channel
+        value: "stable-6.3"

--- a/components/monitoring/logging/internal-production/kustomization.yaml
+++ b/components/monitoring/logging/internal-production/kustomization.yaml
@@ -29,3 +29,12 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: cluster-logging
+    patch: |-
+      - op: replace
+        path: /spec/channel
+        value: "stable-6.3"


### PR DESCRIPTION
**Summary**
- Upgrade ClusterLoggingOperator subscription channel from `stable-6.1` to `stable-6.3` on both production clusters (`kflux-c-prd-e01` and `kflux-c-prd-i01`)
- This is step 1 of a 2-step upgrade (6.1 → 6.3 → 6.4), required because CLO only supports N+2 channel skipping
- Same approach as staging upgrade ([KFLUXINFRA-3862](https://redhat.atlassian.net/browse/KFLUXINFRA-3862), [PR #401](https://github.com/redhat-appstudio/infra-common-deployments/pull/401))

**Changes**
- Added Subscription channel patch (`stable-6.3`) to `internal-production/kustomization.yaml`
- Added Subscription channel patch (`stable-6.3`) to `external-production/kustomization.yaml`

**Validation**
- [x] ArgoCD syncs successfully on both production clusters
- [x] CLO 6.3.x CSV shows `Succeeded` on both clusters
- [x] Logs still reaching Splunk from both clusters

**Next steps**
- After 6.3 is confirmed, a follow-up PR will bump the channel to `stable-6.4` (step 2)
- Final cleanup PR to move `stable-6.4` into base and remove per-env patches

Ref: [KFLUXINFRA-3863](https://redhat.atlassian.net/browse/KFLUXINFRA-3863)


[KFLUXINFRA-3862]: https://redhat.atlassian.net/browse/KFLUXINFRA-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXINFRA-3863]: https://redhat.atlassian.net/browse/KFLUXINFRA-3863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ