### PR TITLE
feat: Promote kargo helm chart version together with kargo images

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/project-config.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/project-config.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   promotionPolicies:
     - stage: ring-1-staging
-      autoPromotionEnabled: false
+      autoPromotionEnabled: true
     - stage: ring-2-production
       autoPromotionEnabled: false

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-1-promote.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-1-promote.yaml
@@ -13,6 +13,8 @@ spec:
       config:
         path: ${{ vars.srcPath }}/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
         updates:
+          - key: version
+            value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
           - key: valuesInline.image.tag
             value: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
           - key: valuesInline.api.oidc.dex.image.tag

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-2-promote.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-2-promote.yaml
@@ -13,6 +13,8 @@ spec:
       config:
         path: ${{ vars.srcPath }}/components/kargo/internal-production/deployment/kargo-helm-generator.yaml
         updates:
+          - key: version
+            value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
           - key: valuesInline.image.tag
             value: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
           - key: valuesInline.api.oidc.dex.image.tag

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -35,6 +35,7 @@ spec:
             message: |
               chore(${{ ctx.stage }}): promote infra-common components
 
+              chart: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
               kargo: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
               dex: ${{ imageFrom("quay.io/konflux-ci/dex").Tag }}
         - uses: git-push
@@ -60,6 +61,7 @@ spec:
 
               | Component | Image | Tag |
               |-----------|-------|-----|
+              | chart | `oci://ghcr.io/akuity/kargo-charts/kargo` | `${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}` |
               | kargo | `quay.io/konflux-ci/kargo` | `${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}` |
               | dex | `quay.io/konflux-ci/dex` | `${{ imageFrom("quay.io/konflux-ci/dex").Tag }}` |
 

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -36,6 +36,7 @@ spec:
             message: |
               chore(${{ ctx.stage }}): promote infra-common components
 
+              chart: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
               kargo: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
               dex: ${{ imageFrom("quay.io/konflux-ci/dex").Tag }}
         - uses: git-push
@@ -61,6 +62,7 @@ spec:
 
               | Component | Image | Tag |
               |-----------|-------|-----|
+              | chart | `oci://ghcr.io/akuity/kargo-charts/kargo` | `${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}` |
               | kargo | `quay.io/konflux-ci/kargo` | `${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}` |
               | dex | `quay.io/konflux-ci/dex` | `${{ imageFrom("quay.io/konflux-ci/dex").Tag }}` |
 

--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse.yaml
@@ -7,6 +7,11 @@ spec:
   freightCreationPolicy: Automatic
   interval: 5m0s
   subscriptions:
+    - chart:
+        repoURL: oci://ghcr.io/akuity/kargo-charts
+        name: kargo
+        semverConstraint: ^1.10.0
+        discoveryLimit: 5
     - image:
         repoURL: quay.io/konflux-ci/kargo
         imageSelectionStrategy: NewestBuild


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Promote Kargo Helm chart version alongside Kargo/Dex images
<code>✨ Enhancement</code> <code>⚙️ Configuration changes</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Enable automatic promotion into ring-1 staging to reduce manual release overhead.
• Track the Kargo Helm chart as freight and promote its version with image tags.
• Surface promoted chart/image versions in commit and PR descriptions for traceability.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
ST1["Stage: ring-1"] --> PT1["PromotionTask: ring-1"] --> REPO{{"infra-common-deployments"}}
ST2["Stage: ring-2"] --> PT2["PromotionTask: ring-2"] --> REPO
W["Warehouse: kargo"] --> CH{{"Kargo chart OCI"}} --> PT1
W --> IR{{"Kargo/Dex images"}} --> PT1
W --> CH --> PT2
W --> IR --> PT2
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Derive chart version from the Kargo image tag</b></summary>

- ➕ Guarantees chart/image alignment when releases are tightly coupled
- ➕ Avoids promoting a new chart without a corresponding image build
- ➖ Assumes a 1:1 mapping between chart and image versions
- ➖ Harder if chart has independent patch releases or metadata versions

</details>

<details>
<summary><b>2. Keep chart version pinned in Git (manual bump) and only auto-promote images</b></summary>

- ➕ Maximum reproducibility and control over chart upgrades
- ➕ Reduces risk of unexpected chart behavior changes
- ➖ More manual work and slower rollouts
- ➖ Less consistent traceability if chart changes are handled out-of-band

</details>

**Recommendation:** The PR’s approach (subscribe to the chart in the Warehouse and update `version` via `chartFrom(...).Version`) is the most idiomatic Kargo pattern and keeps promotions fully declarative. The main follow-up is operational: ensure chart semver constraints and image tag constraints remain compatible so freight doesn’t combine incompatible chart/image pairs.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>ring-1-promote.yaml</strong> <code>Promote Helm chart version in ring-1 task</code> <code>+2/-0</code></summary>

<br/>

>Promote Helm chart version in ring-1 task
>
><pre>
>• Extends the yaml-update step to also set the Helm chart &#x27;version&#x27; using &#x27;chartFrom(...).Version&#x27;. This promotes chart version in the same change set as Kargo/Dex image tags.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/450/files#diff-565765f62f603d1ab77b2fa6008bab407c1c7b5fd0a14c4b6e409f47e8bee77b'>components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-1-promote.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ring-2-promote.yaml</strong> <code>Promote Helm chart version in ring-2 task</code> <code>+2/-0</code></summary>

<br/>

>Promote Helm chart version in ring-2 task
>
><pre>
>• Mirrors ring-1 behavior by updating the production helm generator with the chart &#x27;version&#x27; from the OCI chart subscription. Keeps ring-1 and ring-2 promotion semantics consistent.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/450/files#diff-cd3d2be1100d33aeda664f5294d8c4f3a039490d40178ac23e3abe161326c779'>components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-2-promote.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>warehouse.yaml</strong> <code>Subscribe Warehouse to Kargo Helm chart releases</code> <code>+5/-0</code></summary>

<br/>

>Subscribe Warehouse to Kargo Helm chart releases
>
><pre>
>• Adds an OCI chart subscription for &#x27;kargo&#x27; with a &#x27;^1.10.0&#x27; semver constraint and a small discovery window. This enables Kargo freight creation to include chart versions in addition to image tags.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/450/files#diff-5e777f3137986b8a969a3e1437cca6758932d1959aff93452a60235d68f3c8d1'>components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>project-config.yaml</strong> <code>Enable ring-1 staging auto-promotion</code> <code>+1/-1</code></summary>

<br/>

>Enable ring-1 staging auto-promotion
>
><pre>
>• Turns on &#x27;autoPromotionEnabled&#x27; for the &#x27;ring-1-staging&#x27; promotion policy. This allows staging promotions to proceed automatically while keeping production manual/controlled.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/450/files#diff-98e6edd745fe2c32ae9256655c8e512061f39907e81b62d2a5580de0ec18d496'>components/kargo/internal-production/projects/kargo-infra-common/base/project-config.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>stage-ring-1-staging.yaml</strong> <code>Include chart version in staging promotion commit/PR text</code> <code>+2/-0</code></summary>

<br/>

>Include chart version in staging promotion commit/PR text
>
><pre>
>• Adds the promoted chart version to the git commit message body and to the generated PR description table. Improves auditability of what was promoted into staging.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/450/files#diff-8b5019e143336ac54b84d33edaf173380d57c1d1f58c582d162e8e89cbfd1a41'>components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>stage-ring-2-production.yaml</strong> <code>Include chart version in production promotion commit/PR text</code> <code>+2/-0</code></summary>

<br/>

>Include chart version in production promotion commit/PR text
>
><pre>
>• Adds the promoted chart version to the production ring’s commit message and PR description table. Aligns production reporting with staging.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/450/files#diff-5e4404e731011028601ea3daa11c04cc7ba07e1331fbc1b237f0b6d0d6731b7f'>components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>