### PR TITLE
[KFLUXINFRA-3863] Upgrade ClusterLoggingOperator to 6.4 in production clusters

### DIFF
--- a/components/monitoring/logging/base/install-logging-operator.yaml
+++ b/components/monitoring/logging/base/install-logging-operator.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  channel: "stable-6.1"
+  channel: "stable-6.4"
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/components/monitoring/logging/external-production/kustomization.yaml
+++ b/components/monitoring/logging/external-production/kustomization.yaml
@@ -29,12 +29,3 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: cluster-logging
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: "stable-6.3"

--- a/components/monitoring/logging/external-staging/kustomization.yaml
+++ b/components/monitoring/logging/external-staging/kustomization.yaml
@@ -29,12 +29,3 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: cluster-logging
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: "stable-6.4"

--- a/components/monitoring/logging/internal-production/kustomization.yaml
+++ b/components/monitoring/logging/internal-production/kustomization.yaml
@@ -29,12 +29,3 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: cluster-logging
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: "stable-6.3"

--- a/components/monitoring/logging/internal-staging/kustomization.yaml
+++ b/components/monitoring/logging/internal-staging/kustomization.yaml
@@ -29,12 +29,3 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: cluster-logging
-    patch: |-
-      - op: replace
-        path: /spec/channel
-        value: "stable-6.4"


### PR DESCRIPTION
**Summary**
- Upgrade ClusterLoggingOperator subscription channel to stable-6.4 across all clusters
- Move channel from stable-6.1 to stable-6.4 in base and remove per-environment overlay patches used for the staged rollout
- Step 2 of 2-step upgrade (6.1 → 6.3 → 6.4), completing the CLO upgrade needed to unblock OCP 4.18 → 4.19
- Step 1 was PR #449, staging was done in [KFLUXINFRA-3862](https://redhat.atlassian.net/browse/KFLUXINFRA-3862) (PR [#401](https://github.com/redhat-appstudio/infra-common-deployments/pull/401), [PR #406](https://github.com/redhat-appstudio/infra-common-deployments/pull/406))

**Changes**
- Updated base/install-logging-operator.yaml channel from stable-6.1 to stable-6.4
- Removed Subscription channel patches from internal-staging/kustomization.yaml and external-staging/kustomization.yaml
- Removed Subscription channel patches from internal-production/kustomization.yaml and external-production/kustomization.yaml

**Validation**
- [ ] ArgoCD syncs successfully on all 4 clusters
- [ ] CLO 6.4.x CSV shows Succeeded on both production clusters
- [ ] Logs still reaching Splunk from all clusters

Ref: [KFLUXINFRA-3863](https://redhat.atlassian.net/browse/KFLUXINFRA-3863)

[KFLUXINFRA-3863]: https://redhat.atlassian.net/browse/KFLUXINFRA-3863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KFLUXINFRA-3862]: https://redhat.atlassian.net/browse/KFLUXINFRA-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ