### PR TITLE
fix: Fix the kargo helmchart warehouse

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/project-config.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/project-config.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   promotionPolicies:
     - stage: ring-1-staging
-      autoPromotionEnabled: false
+      autoPromotionEnabled: true
     - stage: ring-2-production
       autoPromotionEnabled: false

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-1-promote.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-1-promote.yaml
@@ -13,6 +13,8 @@ spec:
       config:
         path: ${{ vars.srcPath }}/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
         updates:
+          - key: version
+            value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
           - key: valuesInline.image.tag
             value: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
           - key: valuesInline.api.oidc.dex.image.tag

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-2-promote.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-2-promote.yaml
@@ -13,6 +13,8 @@ spec:
       config:
         path: ${{ vars.srcPath }}/components/kargo/internal-production/deployment/kargo-helm-generator.yaml
         updates:
+          - key: version
+            value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
           - key: valuesInline.image.tag
             value: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
           - key: valuesInline.api.oidc.dex.image.tag

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -12,6 +12,11 @@ spec:
         name: kargo
       sources:
         direct: true
+    - origin:
+        kind: Warehouse
+        name: kargo-helm
+      sources:
+        direct: true
   promotionTemplate:
     spec:
       steps:
@@ -35,6 +40,7 @@ spec:
             message: |
               chore(${{ ctx.stage }}): promote infra-common components
 
+              chart: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
               kargo: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
               dex: ${{ imageFrom("quay.io/konflux-ci/dex").Tag }}
         - uses: git-push
@@ -60,6 +66,7 @@ spec:
 
               | Component | Image | Tag |
               |-----------|-------|-----|
+              | chart | `oci://ghcr.io/akuity/kargo-charts/kargo` | `${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}` |
               | kargo | `quay.io/konflux-ci/kargo` | `${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}` |
               | dex | `quay.io/konflux-ci/dex` | `${{ imageFrom("quay.io/konflux-ci/dex").Tag }}` |
 

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -13,6 +13,12 @@ spec:
       sources:
         stages:
           - ring-1-staging
+    - origin:
+        kind: Warehouse
+        name: kargo-helm
+      sources:
+        stages:
+          - ring-1-staging
   promotionTemplate:
     spec:
       steps:
@@ -36,6 +42,7 @@ spec:
             message: |
               chore(${{ ctx.stage }}): promote infra-common components
 
+              chart: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}
               kargo: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
               dex: ${{ imageFrom("quay.io/konflux-ci/dex").Tag }}
         - uses: git-push
@@ -61,6 +68,7 @@ spec:
 
               | Component | Image | Tag |
               |-----------|-------|-----|
+              | chart | `oci://ghcr.io/akuity/kargo-charts/kargo` | `${{ chartFrom("oci://ghcr.io/akuity/kargo-charts", "kargo").Version }}` |
               | kargo | `quay.io/konflux-ci/kargo` | `${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}` |
               | dex | `quay.io/konflux-ci/dex` | `${{ imageFrom("quay.io/konflux-ci/dex").Tag }}` |
 

--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - warehouse.yaml
+  - warehouse-helm.yaml

--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse-helm.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse-helm.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: kargo-helm
+spec:
+  freightCreationPolicy: Automatic
+  interval: 5m0s
+  subscriptions:
+    - chart:
+        repoURL: oci://ghcr.io/akuity/kargo-charts
+        name: kargo
+        semverConstraint: ^1.10.0
+        discoveryLimit: 5


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix Kargo promotion to track and promote Helm chart versions
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Enable automatic promotion for ring-1 staging.
• Add a dedicated Helm chart Warehouse and wire it into ring-1/ring-2 stages.
• Update promotion tasks to write the chart version alongside image tags.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  Wimg(["Warehouse: kargo image"]) --> S1["Stage: ring-1"] --> T1(["Promote task: ring-1"]) --> G[("Git: env repo")]
  Whelm(["Warehouse: kargo chart"]) --> S1 --> S2["Stage: ring-2"] --> T2(["Promote task: ring-2"]) --> G
  Whelm --> S2

  subgraph Legend
    direction LR
    _wh(["Warehouse"]) ~~~ _st["Stage"] ~~~ _pt(["Promotion task"]) ~~~ _git[("Git repo")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Add chart subscription to existing Warehouse</b></summary>

- ➕ Fewer Kargo resources to manage (single Warehouse origin)
- ➕ Less duplication in stage origin configuration
- ➖ Mixes image and chart concerns, making provenance and filtering harder
- ➖ May complicate future policy differences between image vs chart freight

</details>

<details>
<summary><b>2. Pin chart version in Git and avoid chartFrom()</b></summary>

- ➕ Fully Git-driven promotions; no runtime registry discovery dependency
- ➕ Reproducible without OCI chart lookups during promotion
- ➖ Adds manual work/automation elsewhere to bump chart versions
- ➖ Loses Kargo-native freight tracking for chart releases

</details>

**Recommendation:** The PR’s approach (a dedicated Helm chart Warehouse plus promotion-task updates) is a solid fix that restores end-to-end tracking of the Helm chart version as first-class freight. Consider consolidating into the existing Warehouse only if you explicitly want a single origin and don’t foresee diverging policies between images and charts.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>warehouse-helm.yaml</strong> <code>Define kargo-helm Warehouse subscribing to OCI Helm chart</code> <code>+14/-0</code></summary>

<br/>

>Define kargo-helm Warehouse subscribing to OCI Helm chart
>
><pre>
>• Introduces a Warehouse that automatically discovers kargo chart versions from ghcr.io/akuity/kargo-charts with a semver constraint (^1.10.0). Configures periodic discovery and a small discovery limit.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/452/files#diff-ac48e2ea93140bed546e1f9f4c8e513c5a0a3e4b7f2f53fe418455240216e90e'>components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse-helm.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>project-config.yaml</strong> <code>Enable ring-1 auto-promotion</code> <code>+1/-1</code></summary>

<br/>

>Enable ring-1 auto-promotion
>
><pre>
>• Turns on autoPromotionEnabled for the ring-1-staging policy. This allows ring-1 to advance automatically once freight is available.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/452/files#diff-98e6edd745fe2c32ae9256655c8e512061f39907e81b62d2a5580de0ec18d496'>components/kargo/internal-production/projects/kargo-infra-common/base/project-config.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (5)</summary>

<blockquote>
<details>
<summary><strong>ring-1-promote.yaml</strong> <code>Write Helm chart version during ring-1 promotion</code> <code>+2/-0</code></summary>

<br/>

>Write Helm chart version during ring-1 promotion
>
><pre>
>• Adds an update to set the manifest generator &#x27;version&#x27; field from the discovered Helm chart version. Keeps existing image tag updates intact.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/452/files#diff-565765f62f603d1ab77b2fa6008bab407c1c7b5fd0a14c4b6e409f47e8bee77b'>components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-1-promote.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ring-2-promote.yaml</strong> <code>Write Helm chart version during ring-2 promotion</code> <code>+2/-0</code></summary>

<br/>

>Write Helm chart version during ring-2 promotion
>
><pre>
>• Mirrors ring-1 by adding an update that sets &#x27;version&#x27; from the Helm chart discovered in the OCI repo. Ensures production promotions advance the chart version alongside images.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/452/files#diff-cd3d2be1100d33aeda664f5294d8c4f3a039490d40178ac23e3abe161326c779'>components/kargo/internal-production/projects/kargo-infra-common/base/promotiontasks/ring-2-promote.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>stage-ring-1-staging.yaml</strong> <code>Add Helm chart Warehouse as ring-1 stage origin and include chart in messages</code> <code>+7/-0</code></summary>

<br/>

>Add Helm chart Warehouse as ring-1 stage origin and include chart in messages
>
><pre>
>• Adds a new origin referencing the kargo-helm Warehouse so ring-1 consumes chart freight directly. Also includes the chart version in the commit message and promotion summary table for traceability.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/452/files#diff-8b5019e143336ac54b84d33edaf173380d57c1d1f58c582d162e8e89cbfd1a41'>components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>stage-ring-2-production.yaml</strong> <code>Add Helm chart Warehouse as ring-2 stage origin and include chart in messages</code> <code>+8/-0</code></summary>

<br/>

>Add Helm chart Warehouse as ring-2 stage origin and include chart in messages
>
><pre>
>• Adds a kargo-helm Warehouse origin (stage-sourced from ring-1) so production consumes chart freight consistently. Also records the chart version in the promotion commit message and summary output.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/452/files#diff-5e4404e731011028601ea3daa11c04cc7ba07e1331fbc1b237f0b6d0d6731b7f'>components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>kustomization.yaml</strong> <code>Include Helm chart Warehouse manifest</code> <code>+1/-0</code></summary>

<br/>

>Include Helm chart Warehouse manifest
>
><pre>
>• Adds the new warehouse-helm.yaml to the Kustomize resources so it is applied with the rest of the Kargo resources.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/452/files#diff-5c4ebfa0964b2b1f23293413a900d3f4663a1c74fbb378613c6b8a7e674e2d2b'>components/kargo/internal-production/projects/kargo-infra-common/kargo/kustomization.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>