### PR TITLE
KFLUXINFRA-3771: add AI skills for infra-common-deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,11 @@ kustomize build <path> | kubectl apply --dry-run=client -f -
 - Chainsaw tests require Kyverno fully rolled out (300s timeout).
 - Environment patches target ApplicationSets by group/version/kind —
   changing ApplicationSet structure may silently break patches.
+
+## Skills
+
+- Before opening a PR, writing a PR description, or interpreting CI
+  results, read `skills/pr-workflow.md`
+- When a CI check fails on a PR, read `skills/ci-troubleshooting.md`
+- When working interactively on new features or significant changes,
+  read `skills/brainstorming-workflow.md` before making changes

--- a/skills/brainstorming-workflow.md
+++ b/skills/brainstorming-workflow.md
@@ -1,0 +1,66 @@
+---
+name: brainstorming-workflow
+description: >
+  Use when in an interactive session and the user requests a new feature, significant
+  change, or migration in infra-common-deployments. Provides a structured process
+  choice before any changes are made. Skip when dispatched with a complete task.
+---
+
+# Brainstorming Workflow
+
+Discipline for interactive sessions involving new features, overlay restructuring, component additions, or other significant changes.
+
+## Context Detection
+
+- **Interactive session** (human in CLI/IDE): follow this workflow.
+- **Dispatched with a complete task** (sub-agent, automation, explicit spec): skip entirely and execute.
+
+## First Message
+
+**Always ask this question first**, even when the request sounds urgent. It's a quick check that keeps things on track. Your first message must contain **exactly this question and nothing else** — no clarifying questions, no context gathering, no implementation details.
+
+> I can approach this a few ways:
+>
+> A) Jump straight to making changes
+> B) Discuss approaches first, then make changes
+> C) Full design process — explore approaches, write up a plan, then execute
+>
+> Which works for you?
+
+That's it. One question. Wait for the answer before asking anything else.
+
+**After asking**, if the human replies with "just do it", gives a direct instruction, or otherwise signals urgency, treat as **A**. But ask first — don't skip the question based on tone or urgency cues in the initial request.
+
+## Path A — Jump to Changes
+
+Proceed directly. All existing conventions still apply (pr-workflow, kustomize build validation). No additional ceremony.
+
+## Path B — Discuss Approaches
+
+1. **Understand the problem**: what is being changed, why, and any constraints.
+2. **Propose 2-3 approaches** with trade-offs (blast radius, complexity, number of PRs, staging-first implications).
+3. **Lead with a recommendation** and explain why.
+4. Let the human choose, then execute.
+
+Examples where this helps:
+- Deciding whether a component change needs staging-first or qualifies as a hotfix
+- Planning how to restructure component overlays across internal/external clusters
+- Choosing between adding a new ApplicationSet vs. extending an existing one
+- Evaluating whether a kustomize component (`k-components/`) makes sense vs. duplicating patches
+
+Ask one question at a time. Prefer multiple choice over open-ended questions.
+
+## Path C — Full Design Process
+
+Everything in Path B, plus:
+
+1. **Write up the plan** — what changes in which files, which environments, how many PRs.
+2. **Break into ordered steps** with dependencies (e.g., staging PR first, then production PR).
+3. Get human approval before executing.
+
+## Key Principles
+
+- **One question at a time.** Never pile up multiple questions in one message.
+- **Prefer multiple choice.** Easier for the human to decide quickly.
+- **Human decides the process, not the agent.** Respect the chosen path.
+- **"Just do it" means just do it.** Don't add process the human didn't ask for.

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -1,0 +1,122 @@
+---
+name: ci-troubleshooting
+description: >
+  Use when a CI check fails on a PR in infra-common-deployments and you need to
+  understand what failed, how to read the logs, and how to fix it.
+---
+
+# CI Troubleshooting
+
+## Overview
+
+How to investigate and fix CI failures on infra-common-deployments PRs. This repo uses GitHub Actions and Prow for CI — there are no E2E tests and `/retest` does not apply here.
+
+## When to Use
+
+- A CI check failed on your PR
+- You need to understand what a CI comment or status means
+- You want to re-run a failed check
+
+## Prerequisites
+
+Verify `gh` CLI is installed and authenticated:
+
+```bash
+gh auth status
+```
+
+## Reading CI Logs
+
+### GitHub Actions checks
+
+```bash
+gh pr checks <PR-number> --repo redhat-appstudio/infra-common-deployments
+```
+
+To investigate a failed check:
+
+```bash
+gh run view <run-id> --repo redhat-appstudio/infra-common-deployments
+gh run view <run-id> --repo redhat-appstudio/infra-common-deployments --log-failed
+```
+
+### Prow checks
+
+Prow runs `yamllint` separately. Find Prow statuses and their log URLs:
+
+```bash
+gh api repos/redhat-appstudio/infra-common-deployments/commits/<sha>/statuses \
+  --jq '.[] | select(.context | startswith("ci/prow")) | "\(.context) — \(.state) — \(.target_url)"'
+```
+
+The `target_url` is the Prow log viewer page. Open it in a browser or fetch it to read logs. That page also contains a "Prow Job YAML" link with the prowjob UUID — use it to inspect the full ProwJob resource:
+
+```
+https://prow.ci.openshift.org/prowjob?prowjob=<prowjob-uuid>
+```
+
+This shows the ProwJob spec, cluster assignment, timeouts, and final status — useful for debugging infrastructure issues (pod scheduling, timeout config, secret mounts).
+
+## CI Checks Reference
+
+| Check | Source | Triggers On | What It Does |
+|-------|--------|-------------|--------------|
+| **yamllint** | GitHub Actions | All PRs, pushes to main | YAML formatting validation |
+| **yamllint** | Prow (`ci/prow/yamllint`) | All PRs | Same validation, separate system |
+| **kube-linter** | GitHub Actions | All PRs, pushes to main | Kubernetes manifest best-practice scans |
+| **chainsaw-tests** | GitHub Actions | `components/kyverno/**`, `components/policies/**` | Kyverno policy integration tests in Kind |
+| **agents-md-lint** | GitHub Actions | `AGENTS.md` changes | Validates AGENTS.md stays under 300 lines |
+| **pr-assigner** | GitHub Actions | PR opened/updated | Auto-assigns reviewers from CODEOWNERS |
+| **tide** | Prow | All PRs | Merge automation — manages merge queue |
+
+## Common Failures
+
+### yamllint
+
+YAML formatting errors (trailing whitespace, wrong indentation, missing newline at end of file). The CI logs show the exact file and line. Fix those directly, or run `yamllint .` locally to reproduce.
+
+Both GitHub Actions and Prow run yamllint — both must pass.
+
+### kube-linter
+
+Scans kustomized Kubernetes manifests for security and best practice violations. Check the logs for specific rule violations.
+
+To reproduce locally:
+
+```bash
+mkdir -p kustomizedfiles
+kustomize build argo-cd-apps/overlays/<env>/ -o kustomizedfiles/<env>.yaml
+kube-linter lint --config .kube-linter.yaml kustomizedfiles/
+```
+
+**Note:** kube-linter excludes `kargo/` and `konflux-devlake/` (Helm-based components).
+
+### chainsaw-tests
+
+Path-triggered on `components/kyverno/**` and `components/policies/**` changes. Runs Kyverno policy tests in a Kind cluster.
+
+Often flaky due to infrastructure issues (Kyverno rollout timeout, Kind cluster provisioning). If logs show no relevant errors and the PR looks correct, re-run the failed job:
+
+```bash
+# Find the run ID from pr checks
+gh pr checks <PR-number> --repo redhat-appstudio/infra-common-deployments
+# Re-run just the failed jobs
+gh run rerun <run-id> --repo redhat-appstudio/infra-common-deployments --failed
+```
+
+To run locally:
+
+```bash
+# Set up Kind cluster with Kyverno (300s timeout for rollout)
+hack/chainsaw/chainsaw-prepare.sh
+# Run specific tests
+chainsaw test --config .chainsaw.yaml <test-dir>
+```
+
+### agents-md-lint
+
+Fails if AGENTS.md exceeds 300 lines. Trim content or move details into skills files.
+
+### tide (Prow)
+
+Tide manages the merge queue. A pending `tide` status is normal — it means the PR is waiting for approval or required checks. Not a failure unless it stays stuck after all checks pass and approvals are in place.

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -81,15 +81,24 @@ Both GitHub Actions and Prow run yamllint — both must pass.
 
 Scans kustomized Kubernetes manifests for security and best practice violations. Check the logs for specific rule violations.
 
-To reproduce locally:
+To reproduce locally (must match CI — build ALL kustomizations, not just one overlay):
 
 ```bash
 mkdir -p kustomizedfiles
-kustomize build argo-cd-apps/overlays/<env>/ -o kustomizedfiles/<env>.yaml
+find argo-cd-apps components -name 'kustomization.yaml' \
+  ! -path 'components/kargo/*' \
+  ! -path 'components/konflux-devlake/*' \
+  | xargs -I {} -n1 -P8 bash -c '
+    dir=$(dirname "{}")
+    output_file=$(echo $dir | tr / -)-kustomization.yaml
+    kustomize build --enable-helm "$dir" -o "kustomizedfiles/$output_file"
+  '
 kube-linter lint --config .kube-linter.yaml kustomizedfiles/
 ```
 
-**Note:** kube-linter excludes `kargo/` and `konflux-devlake/` (Helm-based components).
+Building only a single overlay will miss failures CI catches on other kustomizations.
+
+If Helm-based overlays fail locally, compare your local `helm version` and `kustomize version` with CI's versions (see `.github/workflows/kube-linter.yaml` for the kustomize version CI uses).
 
 ### chainsaw-tests
 

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -1,0 +1,150 @@
+---
+name: pr-workflow
+description: >
+  Use when opening, monitoring, or iterating on a pull request in
+  infra-common-deployments, including PR body template, CI interpretation,
+  staging-first requirements, commit conventions, and environment-specific
+  validation.
+---
+
+# PR Workflow
+
+Full lifecycle reference for pull requests in infra-common-deployments.
+
+## Overview
+
+infra-common-deployments is a GitOps monorepo deploying shared infrastructure components via Kustomize and ArgoCD across four environments: `internal-staging`, `external-staging`, `internal-production`, `external-production`. PRs always target the upstream repository (`redhat-appstudio/infra-common-deployments`), never the fork.
+
+## When to Use
+
+- About to open a PR or write a PR description
+- Preparing a production change and unsure about staging-first requirements
+- Promoting a change from staging to production
+
+## Branch Setup
+
+If a dedicated branch already exists for this work, use it. Otherwise, create a branch from the latest main.
+
+First, find which remote points to `redhat-appstudio/infra-common-deployments`:
+
+```bash
+git remote -v | grep redhat-appstudio/infra-common-deployments
+```
+
+Then fetch and branch from it:
+
+```bash
+git fetch <remote>
+git checkout -b <branch-name> <remote>/main --no-track
+```
+
+Never branch from an old or diverged main.
+
+## PR Body Template
+
+Every PR follows this structure:
+
+```markdown
+## What
+
+<concise list of what changed>
+
+Environments affected: <list environments>
+
+[KFLUXINFRA-1234](https://redhat.atlassian.net/browse/KFLUXINFRA-1234)
+
+## Why
+
+<motivation — why this change is needed>
+
+## Validation
+
+- `kustomize build` passes for all affected overlays
+- <staging PR link, test results, other evidence>
+
+## Risk Assessment
+
+**Risk Level:** Low / Medium / High / Critical
+**What could go wrong:** <describe what breaks if this change is incorrect>
+**Rollback:** Revert PR / <specific rollback steps>
+<explanation of risk and blast radius>
+```
+
+**Rules:**
+- **What** — Concise change list, affected environments, Jira link at the bottom. Don't explain why here.
+- **Why** — Motivation only. Keep it brief.
+- **Validation** — Proof, not explanation. kustomize build results, staging links.
+- **Risk Assessment** — Required for production PRs. May be omitted for staging.
+
+## Commit Conventions
+
+Prefix every commit with the Jira key when applicable:
+
+```
+KFLUXINFRA-1234: short description of the change
+```
+
+Always use `-s` flag (DCO sign-off).
+
+Trailers (at end of commit message body). Use the actual agent/tool identity:
+- Interactive sessions (human + agent): `Assisted-by:` trailer
+- Agentic workflow (autonomous): `Authored-by:` trailer
+
+## Pre-Push Validation
+
+Run `kustomize build` on each affected directory containing a `kustomization.yaml`:
+
+```bash
+kustomize build argo-cd-apps/overlays/<env>/
+```
+
+Mention the results in the Validation section of the PR body.
+
+## Staging-First Promotion
+
+Changes must go to **staging first**, then production. This is a team convention — no CI check enforces it.
+
+**Flow:**
+1. Create a PR with staging changes (`internal-staging` and/or `external-staging`)
+2. Get it merged and validated in staging
+3. Create a separate PR for production (`internal-production` and/or `external-production`)
+4. Reference the staging PR in the production PR's Validation section
+
+**Hotfix exception:** If the change is a critical production hotfix, you may go directly to production. Document why staging was skipped in the PR body.
+
+Each environment overlay is **self-contained** — never create shared base layers between staging and production.
+
+## Production PR Requirements
+
+- **Risk Assessment** section is mandatory (level, what could go wrong, rollback plan, blast radius).
+- Reference the staging PR or evidence in the Validation section.
+- When applying to both internal and external production, confirm with the human whether to split into separate PRs or apply together.
+
+## Key CI Checks
+
+| Check | Triggers On | What It Does |
+|-------|-------------|--------------|
+| **yamllint** (GHA + Prow) | All PRs | YAML formatting validation |
+| **kube-linter** | All PRs | Kubernetes manifest best-practice scans |
+| **chainsaw-tests** | `kyverno/**`, `policies/**` | Kyverno policy integration tests |
+| **agents-md-lint** | `AGENTS.md` changes | Validates AGENTS.md under 300 lines |
+| **pr-assigner** | PR opened/updated | Auto-assigns reviewers |
+
+See `skills/ci-troubleshooting.md` for debugging failed checks.
+
+## Interactive Sessions
+
+In interactive sessions (human + agent), always confirm with the human before pushing and opening the PR. Show them the commit message, PR title, and PR body for approval first. Never push or create a PR without explicit approval.
+
+Always use the `-s` flag (DCO sign-off) on all commits.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Skipping staging and going straight to production | Create staging PR first, then production |
+| Forgetting Risk Assessment on a production PR | Add the section — reviewers will block without it |
+| Not running `kustomize build` before pushing | Run it on all affected overlays, mention in Validation |
+| Putting explanation in Validation instead of proof | Validation = evidence (build output, staging links). Why = explanation. |
+| Branching from a stale main | Always fetch and reset from upstream before branching |
+| Creating PR against fork instead of upstream | Use `gh pr create --repo redhat-appstudio/infra-common-deployments` |

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -126,7 +126,7 @@ Each environment overlay is **self-contained** — never create shared base laye
 |-------|-------------|--------------|
 | **yamllint** (GHA + Prow) | All PRs | YAML formatting validation |
 | **kube-linter** | All PRs | Kubernetes manifest best-practice scans |
-| **chainsaw-tests** | `kyverno/**`, `policies/**` | Kyverno policy integration tests |
+| **chainsaw-tests** | `components/kyverno/**`, `components/policies/**` | Kyverno policy integration tests |
 | **agents-md-lint** | `AGENTS.md` changes | Validates AGENTS.md under 300 lines |
 | **pr-assigner** | PR opened/updated | Auto-assigns reviewers |
 


### PR DESCRIPTION
## What

Add three AI skills to the `skills/` directory and reference them from AGENTS.md:
- `brainstorming-workflow.md` — structured process choice (A/B/C) before significant changes
- `ci-troubleshooting.md` — CI check reference and debugging guide (yamllint, kube-linter, chainsaw, agents-md-lint, Prow)
- `pr-workflow.md` — PR lifecycle: body template, staging-first promotion, commit conventions, production requirements

Environments affected: none (documentation only)

[KFLUXINFRA-3771](https://redhat.atlassian.net/browse/KFLUXINFRA-3771)

## Why

Enable AI agents working in this repository to follow team conventions for brainstorming, CI debugging, and PR workflows without re-deriving them from scratch each session.

## Validation

- `kustomize build` not affected (no manifest changes)
- Skills tested with RED/GREEN subagent pattern — verified agents follow conventions with skills loaded vs. baseline without
- AGENTS.md stays under 300-line limit (78 lines)

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Skills contain incorrect conventions that mislead agents
**Rollback:** Revert PR
Documentation-only change — no impact on deployed infrastructure

[KFLUXINFRA-3771]: https://redhat.atlassian.net/browse/KFLUXINFRA-3771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ