### PR TITLE
fix(RELEASE-1673): increase cleanup ir script memory and cpu (staging)

### DIFF
--- a/components/internal-services/internal-staging/cronjob/cleanup-internal-requests-pipelineruns.yaml
+++ b/components/internal-services/internal-staging/cronjob/cleanup-internal-requests-pipelineruns.yaml
@@ -75,11 +75,11 @@ spec:
                   name: temp-directory
               resources:
                 limits:
-                  cpu: 200m
-                  memory: 512Mi
+                  cpu: 1
+                  memory: 4096Mi
                 requests:
-                  cpu: 200m
-                  memory: 512Mi
+                  cpu: 500m
+                  memory: 4096Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
this PR increases the memory and cpu requests/limits
for the Pod in cleanup-internal-requests-pipelineruns
as the job is being OOMKilled as kubectl is returning
too many PRLs