### PR TITLE
 Add kargo skills to onboard new components and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,5 @@ kustomize build <path> | kubectl apply --dry-run=client -f -
 - When a CI check fails on a PR, read `skills/ci-troubleshooting.md`
 - When working interactively on new features or significant changes,
   read `skills/brainstorming-workflow.md` before making changes
+- When onboarding a new component to Kargo automated promotion,
+  read `skills/kargo-onboard.md`

--- a/components/kargo/internal-production/projects/kargo-infra-common/README.md
+++ b/components/kargo/internal-production/projects/kargo-infra-common/README.md
@@ -1,0 +1,347 @@
+# Onboarding a Component to Kargo Promotion
+
+This guide explains how to add a new component to the `kargo-infra-common`
+automated promotion pipeline. Kargo watches container registries and Helm chart
+repositories for new versions, then opens PRs to promote those versions through
+staging and production.
+
+## How Promotion Works
+
+```
+Warehouse                        Stage: staging              Stage: production
+(watches registries)  ──freight──>  (auto-promotes)  ──soak──>  (manual approval)
+                                       │                            │
+                                  PromotionTask               PromotionTask
+                                  updates staging              updates production
+                                  config files                 config files
+                                       │                            │
+                                  Opens PR to main            Opens PR to main
+                                  Waits for merge             Waits for merge
+```
+
+**Key concepts:**
+
+- **Warehouse** — watches image registries / Helm repos and creates "freight"
+  (a versioned bundle of artifacts) when new versions appear.
+- **Stage** — represents an environment (staging, production). Each stage
+  consumes freight and runs a promotion template.
+- **PromotionTask** — the reusable logic that updates files in this GitOps
+  repo. Each component has its own task.
+- **Freight origin guard** — each PromotionTask uses
+  `if: ${{ ctx.targetFreight.origin.name == "<warehouse>" }}` so it only
+  executes when its own warehouse produces new freight.
+
+## Directory Layout
+
+```
+kargo-infra-common/
+├── base/                              # shared project resources
+│   ├── namespace.yaml                 # namespace with kargo.akuity.io/project label
+│   ├── project.yaml                   # Kargo Project
+│   ├── project-config.yaml            # promotion policies (auto/manual per stage)
+│   ├── rbac/                          # RBAC for the konflux-devprod group
+│   ├── external-secrets/              # git credentials from Vault
+│   ├── stage-ring-1-staging.yaml      # staging stage (calls all component tasks)
+│   └── stage-ring-2-production.yaml   # production stage (calls component tasks)
+│
+├── kargo/                             # kargo component
+│   ├── kustomization.yaml
+│   ├── warehouse.yaml                 # watches kargo + dex images, kargo helm chart
+│   └── promotiontasks/
+│       ├── kargo-promote-ring-1.yaml  # updates staging config
+│       └── kargo-promote-ring-2.yaml  # updates production config
+│
+├── <your-component>/                  # add your component here
+│   ├── kustomization.yaml
+│   ├── warehouse.yaml
+│   └── promotiontasks/
+│       └── <component>-promote-ring-1.yaml  # at minimum, staging
+│
+└── kustomization.yaml                 # references: base, kargo, <your-component>
+```
+
+Each component owns its **warehouse** (what to watch) and **promotion tasks**
+(what to update). The **stages** in `base/` are shared — they call every
+component's promotion task in sequence within a single promotion, which
+preserves soak time gating between staging and production.
+
+## Step-by-Step: Onboard a New Component
+
+### 1. Create Your Component Directory
+
+```
+kargo-infra-common/<component>/
+├── kustomization.yaml
+├── warehouse.yaml
+└── promotiontasks/
+    ├── kustomization.yaml
+    └── <component>-promote-ring-1.yaml
+```
+
+### 2. Define Your Warehouse
+
+The warehouse tells Kargo what artifacts to watch. It polls every 5 minutes
+and creates freight when new versions appear.
+
+```yaml
+# <component>/warehouse.yaml
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: <component>
+spec:
+  freightCreationPolicy: Automatic
+  interval: 5m0s
+  subscriptions:
+    # Helm chart (if your component deploys via Helm)
+    - chart:
+        repoURL: https://charts.example.com
+        name: <chart-name>
+        semverConstraint: ^1.0.0
+        discoveryLimit: 5
+    # Container images
+    - image:
+        repoURL: quay.io/konflux-ci/<image>
+        imageSelectionStrategy: NewestBuild
+        discoveryLimit: 5
+        allowTags: ^[0-9a-f]{40}$      # SHA tags
+    # Add more images as needed
+```
+
+**`allowTags`** — regex filter for image tags. Common patterns:
+- `^[0-9a-f]{40}$` — full 40-char git SHA
+- `^1\.10-[0-9a-f]{7}$` — semver prefix + short SHA
+- `^v[0-9]+\.[0-9]+\.[0-9]+$` — semver tags
+
+**`imageSelectionStrategy`** — use `NewestBuild` for SHA-tagged images,
+`SemVer` for semver-tagged images.
+
+### 3. Create Your Promotion Task
+
+The promotion task defines which files to update and how. It uses
+`yaml-update` to patch specific keys in your component's config files.
+
+```yaml
+# <component>/promotiontasks/<component>-promote-ring-1.yaml
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: PromotionTask
+metadata:
+  name: <component>-promote-ring-1
+spec:
+  vars:
+    - name: srcPath
+  steps:
+    - uses: yaml-update
+      as: update-<component>
+      if: ${{ ctx.targetFreight.origin.name == "<component>" }}
+      config:
+        path: ${{ vars.srcPath }}/components/<component>/internal-staging/<target-file>
+        updates:
+          - key: <yaml.key.to.update>
+            value: ${{ imageFrom("quay.io/konflux-ci/<image>").Tag }}
+```
+
+**What goes in `updates`** depends on how your component is deployed:
+
+| Deployment Method | Target File | Key to Update |
+|---|---|---|
+| HelmChartInflationGenerator | `kargo-helm-generator.yaml` | `valuesInline.image.tag` |
+| Kustomize `helmCharts:` | `helm-values.yaml` | `<image-key>.tag` |
+| Kustomize `images:` | `kustomization.yaml` | `images.0.newTag` |
+| Helm chart version | generator or kustomization | `version` (use `chartFrom()`) |
+| Git resource ref | `kustomization.yaml` | `resources.<index>` |
+
+**Expression functions:**
+- `imageFrom("quay.io/repo").Tag` — resolves image tag from freight
+- `chartFrom("oci://registry/chart").Version` — resolves chart version from freight
+
+**If your component also deploys to production**, create `<component>-promote-ring-2.yaml`
+with the same structure but pointing to the production config path
+(`internal-production/` instead of `internal-staging/`).
+
+### 4. Wire Up the Kustomizations
+
+```yaml
+# <component>/kustomization.yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - warehouse.yaml
+  - promotiontasks
+```
+
+```yaml
+# <component>/promotiontasks/kustomization.yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - <component>-promote-ring-1.yaml
+  # - <component>-promote-ring-2.yaml  # if you have production
+```
+
+### 5. Register Your Component in the Top-Level Kustomization
+
+```yaml
+# kustomization.yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kargo-infra-common
+resources:
+  - base
+  - kargo
+  - <component>          # <-- add this line
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+```
+
+### 6. Add Your Warehouse as a Freight Origin in the Stage
+
+Edit `base/stage-ring-1-staging.yaml` — add your warehouse under
+`requestedFreight`:
+
+```yaml
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: kargo
+      sources:
+        direct: true
+    - origin:                    # <-- add this block
+        kind: Warehouse
+        name: <component>
+      sources:
+        direct: true
+```
+
+Then add your promotion task call in the `steps` section, after the existing
+task calls:
+
+```yaml
+      steps:
+        - uses: git-clone
+          ...
+        # --- kargo ---
+        - task:
+            name: kargo-promote-ring-1
+          as: kargo-promote
+          vars:
+            - name: srcPath
+              value: ./src
+        # --- <component> ---          # <-- add this block
+        - task:
+            name: <component>-promote-ring-1
+          as: <component>-promote
+          vars:
+            - name: srcPath
+              value: ./src
+        - uses: git-commit
+          ...
+```
+
+If your component also promotes to production, make the same changes in
+`base/stage-ring-2-production.yaml`.
+
+### 7. Update the Project Config (if needed)
+
+The project config in `base/project-config.yaml` controls auto-promotion.
+The current stages already have policies defined — you only need to edit this
+if you add new stages:
+
+```yaml
+spec:
+  promotionPolicies:
+    - stage: ring-1-staging
+      autoPromotionEnabled: true       # staging auto-promotes
+    - stage: ring-2-production
+      autoPromotionEnabled: false      # production requires manual approval
+```
+
+### 8. Validate
+
+```sh
+# build the kargo-infra-common project
+kustomize build components/kargo/internal-production/projects/kargo-infra-common/
+
+# build the full overlays
+kustomize build --enable-helm components/kargo/internal-staging/
+kustomize build --enable-helm components/kargo/internal-production/
+
+# apply to a local kind cluster for testing (if available)
+kustomize build components/kargo/internal-production/projects/kargo-infra-common/ \
+  | kubectl apply -f -
+```
+
+## Environments
+
+This repo supports four environments across two cluster types:
+
+| Environment | Cluster Type | Kargo Stage | ArgoCD Source Path |
+|---|---|---|---|
+| `internal-staging` | Internal | `ring-1-staging` | `components/<name>/internal-staging` |
+| `internal-production` | Internal | `ring-2-production` | `components/<name>/internal-production` |
+| `external-staging` | External | `ring-1-staging` | `components/<name>/external-staging` |
+| `external-production` | External | `ring-2-production` | `components/<name>/external-production` |
+
+ArgoCD ApplicationSets use `{{values.environment}}` which is patched per
+overlay to the correct environment name. Your component needs a directory
+matching each environment it deploys to (e.g., `internal-staging/`,
+`internal-production/`).
+
+If your component deploys to **external** clusters, your promotion task must
+also update the external config files.
+
+## Example: Kargo Component (Reference)
+
+The `kargo/` directory is the reference implementation:
+
+**Warehouse** — watches the Kargo Helm chart (OCI), Kargo image, and Dex image:
+
+```yaml
+subscriptions:
+  - chart:
+      repoURL: oci://ghcr.io/akuity/kargo-charts/kargo
+      semverConstraint: ^1.10.0
+  - image:
+      repoURL: quay.io/konflux-ci/kargo
+      allowTags: ^1\.10-[0-9a-f]{7}$
+  - image:
+      repoURL: quay.io/konflux-ci/dex
+      allowTags: ^[0-9a-f]{40}$
+```
+
+**Promotion Task** — updates the Helm generator with chart version + image tags:
+
+```yaml
+steps:
+  - uses: yaml-update
+    as: update-kargo
+    if: ${{ ctx.targetFreight.origin.name == "kargo" }}
+    config:
+      path: ${{ vars.srcPath }}/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
+      updates:
+        - key: version
+          value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts/kargo").Version }}
+        - key: valuesInline.image.tag
+          value: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
+        - key: valuesInline.api.oidc.dex.image.tag
+          value: ${{ imageFrom("quay.io/konflux-ci/dex").Tag }}
+```
+
+## Checklist
+
+Before opening your PR:
+
+- [ ] Warehouse created with correct image repos, tag filters, and chart refs
+- [ ] PromotionTask created with `if` guard on `ctx.targetFreight.origin.name`
+- [ ] PromotionTask `path` points to the correct target file in your component
+- [ ] Kustomizations wired up (`<component>/kustomization.yaml` and `promotiontasks/kustomization.yaml`)
+- [ ] Top-level `kustomization.yaml` includes your component
+- [ ] Stage YAML updated with your freight origin and task call
+- [ ] `kustomize build` passes for all overlays
+- [ ] Tested on a local kind cluster (if available)

--- a/components/kargo/internal-production/projects/kargo-infra-common/README.md
+++ b/components/kargo/internal-production/projects/kargo-infra-common/README.md
@@ -298,40 +298,14 @@ also update the external config files.
 
 ## Example: Kargo Component (Reference)
 
-The `kargo/` directory is the reference implementation:
+The [`kargo/`](../kargo/) directory is the reference implementation:
 
-**Warehouse** — watches the Kargo Helm chart (OCI), Kargo image, and Dex image:
-
-```yaml
-subscriptions:
-  - chart:
-      repoURL: oci://ghcr.io/akuity/kargo-charts/kargo
-      semverConstraint: ^1.10.0
-  - image:
-      repoURL: quay.io/konflux-ci/kargo
-      allowTags: ^1\.10-[0-9a-f]{7}$
-  - image:
-      repoURL: quay.io/konflux-ci/dex
-      allowTags: ^[0-9a-f]{40}$
-```
-
-**Promotion Task** — updates the Helm generator with chart version + image tags:
-
-```yaml
-steps:
-  - uses: yaml-update
-    as: update-kargo
-    if: ${{ ctx.targetFreight.origin.name == "kargo" }}
-    config:
-      path: ${{ vars.srcPath }}/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
-      updates:
-        - key: version
-          value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts/kargo").Version }}
-        - key: valuesInline.image.tag
-          value: ${{ imageFrom("quay.io/konflux-ci/kargo").Tag }}
-        - key: valuesInline.api.oidc.dex.image.tag
-          value: ${{ imageFrom("quay.io/konflux-ci/dex").Tag }}
-```
+- **Warehouse** — watches the Kargo Helm chart (OCI), Kargo image, and Dex
+  image: [`kargo/warehouse.yaml`](../kargo/warehouse.yaml)
+- **Promotion Task (staging)** — updates the Helm generator with chart version
+  and image tags: [`kargo/promotiontasks/kargo-promote-ring-1.yaml`](../kargo/promotiontasks/kargo-promote-ring-1.yaml)
+- **Promotion Task (production)** — same pattern targeting production config:
+  [`kargo/promotiontasks/kargo-promote-ring-2.yaml`](../kargo/promotiontasks/kargo-promote-ring-2.yaml)
 
 ## Checklist
 

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/kustomization.yaml
@@ -7,6 +7,5 @@ resources:
   - project-config.yaml
   - rbac
   - external-secrets
-  - promotiontasks
   - stage-ring-1-staging.yaml
   - stage-ring-2-production.yaml

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -28,13 +28,11 @@ spec:
               - branch: main
                 path: ./src
         - task:
-            name: ring-1-promote
-          as: promote
+            name: kargo-promote-ring-1
+          as: kargo-promote
           vars:
             - name: srcPath
               value: ./src
-            - name: component
-              value: ${{ vars.component }}
         - uses: git-commit
           as: commit
           config:

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -29,13 +29,11 @@ spec:
               - branch: main
                 path: ./src
         - task:
-            name: ring-2-promote
-          as: promote
+            name: kargo-promote-ring-2
+          as: kargo-promote
           vars:
             - name: srcPath
               value: ./src
-            - name: component
-              value: ${{ vars.component }}
         - uses: git-commit
           as: commit
           config:

--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - warehouse.yaml
+  - promotiontasks

--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kargo-promote-ring-1.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kargo-promote-ring-1.yaml
@@ -2,15 +2,14 @@
 apiVersion: kargo.akuity.io/v1alpha1
 kind: PromotionTask
 metadata:
-  name: ring-1-promote
+  name: kargo-promote-ring-1
 spec:
   vars:
     - name: srcPath
-    - name: component
   steps:
     - uses: yaml-update
       as: update-kargo
-      if: ${{ vars.component == "kargo" }}
+      if: ${{ ctx.targetFreight.origin.name == "kargo" }}
       config:
         path: ${{ vars.srcPath }}/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
         updates:

--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kargo-promote-ring-2.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kargo-promote-ring-2.yaml
@@ -2,15 +2,14 @@
 apiVersion: kargo.akuity.io/v1alpha1
 kind: PromotionTask
 metadata:
-  name: ring-2-promote
+  name: kargo-promote-ring-2
 spec:
   vars:
     - name: srcPath
-    - name: component
   steps:
     - uses: yaml-update
       as: update-kargo
-      if: ${{ vars.component == "kargo" }}
+      if: ${{ ctx.targetFreight.origin.name == "kargo" }}
       config:
         path: ${{ vars.srcPath }}/components/kargo/internal-production/deployment/kargo-helm-generator.yaml
         updates:

--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kustomization.yaml
@@ -2,5 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ring-1-promote.yaml
-  - ring-2-promote.yaml
+  - kargo-promote-ring-1.yaml
+  - kargo-promote-ring-2.yaml

--- a/skills/kargo-onboard.md
+++ b/skills/kargo-onboard.md
@@ -1,0 +1,203 @@
+---
+name: kargo-onboard
+description: >
+  Use when onboarding a new component to Kargo automated promotion in
+  kargo-infra-common — creating warehouses, promotion tasks, and patching
+  stage files
+---
+
+# Kargo Component Onboarding
+
+Scaffold a new component into the `kargo-infra-common` Kargo promotion
+pipeline.
+
+## Skill Invocation Policy
+
+This skill is **user-invoked only**. It must be run locally by a human operator using Claude Code on their machine — it is not available to Fullsend or any other automated agent framework.
+
+- **Who**: Human users (SREs, component leads) running Claude Code locally.
+- **Not**: Fullsend, CI pipelines, bots, or any headless/automated agent runner.
+- **Why**: Kargo onboarding decisions require human judgment, context, and accountability. Automated agents lack the cross-team context needed to make sound promotion pipeline trade-offs. Every change to these configs should have a human author who can defend the decision in review.
+
+## Gather component details
+
+Ask the user for these details. Use AskUserQuestion to collect them
+interactively. If the user provided some details in their initial message,
+only ask for what's missing.
+
+Required:
+- **Component name** — lowercase kebab-case identifier (e.g., `devlake`, `smee`)
+- **Container image repos** — one or more image URLs to watch (e.g., `quay.io/konflux-ci/devlake-mcp`)
+  - For each image: tag regex pattern (`allowTags`) and selection strategy (`NewestBuild` or `SemVer`)
+
+Optional:
+- **Helm chart repo** — OCI or HTTPS chart URL + semver constraint (e.g., `oci://ghcr.io/charts/myapp`, `^1.0.0`)
+- **Deployment method** — how the component is deployed. Options:
+  - `HelmChartInflationGenerator` — updates a `kargo-helm-generator.yaml` file
+  - `kustomize-helmCharts` — updates values in a Helm values file referenced by kustomization
+  - `kustomize-images` — updates `images.N.newTag` in `kustomization.yaml`
+  - `git-resource-ref` — updates a git resource ref in `kustomization.yaml`
+- **Target config file** — the file path that the promotion task should update,
+  relative to `components/<component>/<environment>/` (e.g., `deployment/kargo-helm-generator.yaml`, `kustomization.yaml`)
+- **YAML keys to update** — which keys to set for each image/chart subscription
+- **Promote to production** — whether to create ring-2 (production) promotion task in addition to ring-1 (staging). Default: yes.
+
+## Generate files
+
+All files go under:
+`components/kargo/internal-production/projects/kargo-infra-common/<component>/`
+
+Read the reference implementation before generating each file.
+
+### 1. Warehouse — `<component>/warehouse.yaml`
+
+Reference: `components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse.yaml`
+
+```yaml
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: <component>
+spec:
+  freightCreationPolicy: Automatic
+  interval: 5m0s
+  subscriptions:
+    # Add chart subscription if Helm chart provided
+    # Add image subscriptions for each container image
+```
+
+### 2. Promotion task (staging) — `<component>/promotiontasks/<component>-promote-ring-1.yaml`
+
+Reference: `components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kargo-promote-ring-1.yaml`
+
+```yaml
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: PromotionTask
+metadata:
+  name: <component>-promote-ring-1
+spec:
+  vars:
+    - name: srcPath
+  steps:
+    - uses: yaml-update
+      as: update-<component>
+      if: ${{ ctx.targetFreight.origin.name == "<component>" }}
+      config:
+        path: ${{ vars.srcPath }}/components/<component>/internal-staging/<target-file>
+        updates:
+          # Add updates for each image/chart key
+```
+
+### 3. Promotion task (production) — `<component>/promotiontasks/<component>-promote-ring-2.yaml`
+
+Same as ring-1 but with `internal-production` in the path instead of `internal-staging`.
+Only create this if the user wants production promotion.
+
+### 4. Promotiontasks kustomization — `<component>/promotiontasks/kustomization.yaml`
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - <component>-promote-ring-1.yaml
+  # - <component>-promote-ring-2.yaml  # if production
+```
+
+### 5. Component kustomization — `<component>/kustomization.yaml`
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - warehouse.yaml
+  - promotiontasks
+```
+
+## Patch existing files
+
+IMPORTANT: These patches are ADDITIVE ONLY. Never remove or modify existing
+entries. Only append new items to existing arrays.
+
+### 6. Top-level kustomization
+
+Read then edit `components/kargo/internal-production/projects/kargo-infra-common/kustomization.yaml`:
+- Add `- <component>` to the `resources` list (before `commonAnnotations`)
+
+### 7. Staging stage
+
+Read then edit `components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml`:
+- Add a new freight origin entry to `spec.requestedFreight`:
+  ```yaml
+  - origin:
+      kind: Warehouse
+      name: <component>
+    sources:
+      direct: true
+  ```
+- Add the promotion task call in `spec.promotionTemplate.spec.steps`,
+  BEFORE the `git-commit` step:
+  ```yaml
+  - task:
+      name: <component>-promote-ring-1
+    as: <component>-promote
+    vars:
+      - name: srcPath
+        value: ./src
+  ```
+
+### 8. Production stage (if applicable)
+
+Read then edit `components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml`:
+- Add a new freight origin entry to `spec.requestedFreight`:
+  ```yaml
+  - origin:
+      kind: Warehouse
+      name: <component>
+    sources:
+      stages:
+        - ring-1-staging
+  ```
+  Note: production sources freight from the staging stage (not `direct: true`).
+- Add the promotion task call in steps, BEFORE `git-commit`:
+  ```yaml
+  - task:
+      name: <component>-promote-ring-2
+    as: <component>-promote
+    vars:
+      - name: srcPath
+        value: ./src
+  ```
+
+## Validate
+
+After generating all files and patching stages, run these checks:
+
+1. **Kustomize build** — must exit 0:
+   ```sh
+   kustomize build components/kargo/internal-production/projects/kargo-infra-common/
+   ```
+2. **Warehouse subscriptions** — verify the built output contains a Warehouse
+   whose `subscriptions` list matches the images/charts the user provided.
+3. **PromotionTask paths** — confirm each task's `config.path` points to the
+   correct environment directory (`internal-staging` for ring-1,
+   `internal-production` for ring-2).
+4. **Stage patching** — confirm `requestedFreight` in both stages references
+   the new Warehouse by name, and `steps` includes the new promotion task
+   before `git-commit`.
+5. **No orphan resources** — every YAML file is listed in a `kustomization.yaml`.
+
+If the build fails, diagnose and fix before reporting success.
+
+## Summary
+
+After completion, tell the user:
+- Which files were created
+- Which existing files were patched (and what was added)
+- Whether `kustomize build` passed
+- Remind them to also create the component's deployment config in the
+  target environment directory (e.g., `components/<component>/internal-staging/`)
+  if it doesn't already exist — that's where the promotion task will write to


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add Kargo component onboarding docs and per-component promotion tasks
<code>✨ Enhancement</code> <code>📝 Documentation</code> <code>⚙️ Configuration changes</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Add onboarding guide and Claude skill to scaffold new Kargo pipeline components.
• Rename/wire Kargo promotion tasks under the kargo component kustomization hierarchy.
• Guard PromotionTask execution by freight origin to prevent cross-component step runs.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  WH[("Warehouse")] --> ST1["Stage: ring-1 (staging)"] --> PT1[["PromotionTask: kargo ring-1"]] --> CFG["GitOps config files"]
  ST1 -->|"soak"| ST2["Stage: ring-2 (production)"] --> PT2[["PromotionTask: kargo ring-2"]] --> CFG
  DOC["Onboarding README"] --> ST1
  SKILL["Claude skill: kargo-onboard"] --> DOC
  subgraph Legend
    direction LR
    _wh[("Warehouse")] ~~~ _st["Stage"] ~~~ _pt[["PromotionTask"]] ~~~ _cfg["Config"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Keep shared promotion tasks under base/</b></summary>

- ➕ Single place to find all promotion logic
- ➕ Avoids duplicating directory scaffolding per component
- ➖ Breaks ownership model (component logic lives outside the component)
- ➖ Doesn’t scale well as more components are onboarded
- ➖ Harder to apply per-component conventions (naming, guards, resources)

</details>

<details>
<summary><b>2. Single parameterized PromotionTask (per ring) for all components</b></summary>

- ➕ Less YAML to maintain (one task per ring)
- ➕ Consistent behavior by construction
- ➖ Requires robust parameter passing and conventions for target paths/keys
- ➖ More complex to support mixed deployment methods (helm generator vs kustomize images vs git refs)
- ➖ Harder to reason about blast radius of a task change

</details>

**Recommendation:** The PR’s approach (component-owned warehouse + promotiontasks, with standardized naming and a freight-origin guard) is the best fit for onboarding many components while keeping promotion logic localized. The freight-origin guard using ctx.targetFreight.origin.name is also a safer execution model than passing a component var through stages/tasks.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Refactor</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>kargo-promote-ring-1.yaml</strong> <code>Rename ring-1 PromotionTask and guard by freight origin</code> <code>+2/-3</code></summary>

<br/>

>Rename ring-1 PromotionTask and guard by freight origin
>
><pre>
>• Renames the PromotionTask to kargo-promote-ring-1 and removes the component var. Switches the step execution guard to ctx.targetFreight.origin.name == &quot;kargo&quot; to ensure the task only runs for kargo-origin freight.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-bca4f372e0e9cae9c899bc2beed13ec6bcd62953c98210cf3e82523defb1fdac'>components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kargo-promote-ring-1.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>kargo-promote-ring-2.yaml</strong> <code>Rename ring-2 PromotionTask and guard by freight origin</code> <code>+2/-3</code></summary>

<br/>

>Rename ring-2 PromotionTask and guard by freight origin
>
><pre>
>• Renames the PromotionTask to kargo-promote-ring-2 and removes the component var. Switches the step execution guard to ctx.targetFreight.origin.name == &quot;kargo&quot; to prevent accidental execution for other components’ freight.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-8e280cdeb050c8f6f0895f3e37380c5a98e4f647f81199dba2a2f4d3aa9ad47c'>components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kargo-promote-ring-2.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>SKILL.md</strong> <code>Add Claude skill to scaffold new Kargo component onboarding</code> <code>+188/-0</code></summary>

<br/>

>Add Claude skill to scaffold new Kargo component onboarding
>
><pre>
>• Introduces a step-by-step interactive skill for collecting component details and generating the standard Kargo warehouse/promotion task/kustomization files. Documents the required patches to top-level kustomization and stage manifests, plus validation steps.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-66c84d04a4d755536f6c1e70dfed9d85eac2f169f2916df03c03173f6878aa28'>.claude/skills/kargo-onboard/SKILL.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>README.md</strong> <code>Add comprehensive onboarding guide for Kargo promotion components</code> <code>+347/-0</code></summary>

<br/>

>Add comprehensive onboarding guide for Kargo promotion components
>
><pre>
>• Adds a full onboarding README describing the warehouse → stage → promotion task flow, directory layout conventions, and per-deployment-method update patterns. Includes concrete examples, checklists, and validation commands for building/applying manifests.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-d3d26276a197893cf23bdf77cd5053c15f3430964503693e3fc538e7b45806aa'>components/kargo/internal-production/projects/kargo-infra-common/README.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (5)</summary>

<blockquote>
<details>
<summary><strong>kustomization.yaml</strong> <code>Stop referencing shared base promotiontasks from kustomization</code> <code>+0/-1</code></summary>

<br/>

>Stop referencing shared base promotiontasks from kustomization
>
><pre>
>• Removes the base-level promotiontasks resource from the project base kustomization, aligning with the per-component promotiontasks ownership model.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-53fd4dc7763e6983ba8222fea0bf977f08520ffbb76f442baf1b0eda6a50a9c8'>components/kargo/internal-production/projects/kargo-infra-common/base/kustomization.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>stage-ring-1-staging.yaml</strong> <code>Update staging stage to call renamed kargo promotion task</code> <code>+2/-2</code></summary>

<br/>

>Update staging stage to call renamed kargo promotion task
>
><pre>
>• Replaces the task reference from the generic ring-1-promote to kargo-promote-ring-1 and updates the step alias to kargo-promote to match naming conventions.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-8b5019e143336ac54b84d33edaf173380d57c1d1f58c582d162e8e89cbfd1a41'>components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>stage-ring-2-production.yaml</strong> <code>Update production stage to call renamed kargo promotion task</code> <code>+2/-2</code></summary>

<br/>

>Update production stage to call renamed kargo promotion task
>
><pre>
>• Replaces the task reference from ring-2-promote to kargo-promote-ring-2 and updates the step alias to kargo-promote for consistency with staging and the new file naming scheme.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-5e4404e731011028601ea3daa11c04cc7ba07e1331fbc1b237f0b6d0d6731b7f'>components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>kustomization.yaml</strong> <code>Include kargo promotiontasks in component kustomization</code> <code>+1/-0</code></summary>

<br/>

>Include kargo promotiontasks in component kustomization
>
><pre>
>• Adds the promotiontasks directory as a resource so the renamed PromotionTask manifests are included when building the kargo component resources.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-5c4ebfa0964b2b1f23293413a900d3f4663a1c74fbb378613c6b8a7e674e2d2b'>components/kargo/internal-production/projects/kargo-infra-common/kargo/kustomization.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>kustomization.yaml</strong> <code>Update promotiontasks kustomization to new task filenames</code> <code>+2/-2</code></summary>

<br/>

>Update promotiontasks kustomization to new task filenames
>
><pre>
>• Updates resources to reference kargo-promote-ring-1.yaml and kargo-promote-ring-2.yaml instead of the previous ring-*-promote.yaml names.
></pre>
>
><a href='https://github.com/redhat-appstudio/infra-common-deployments/pull/463/files#diff-0e26572914ebe4e7079e71aff29fa8600fcae6d8e326965fbe7cc56663ba5347'>components/kargo/internal-production/projects/kargo-infra-common/kargo/promotiontasks/kustomization.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>