### PR TITLE
Promote dummy deployments for testing in commong infra deployments

### DIFF
--- a/argo-cd-apps/overlays/external-staging/dummy-deployment.yaml
+++ b/argo-cd-apps/overlays/external-staging/dummy-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: dummy-deployment
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/dummy-deployment
+          environment: ""
+  template:
+    metadata:
+      name: dummy-deployment-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-dummy-deploy
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/external-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/external-staging/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd-local
 resources:
   - ../../base/all-clusters
   - ../../base/external
+  - dummy-deployment.yaml
 patches:
   - path: environment-patch.yaml
     target:

--- a/argo-cd-apps/overlays/internal-staging/dummy-deployment.yaml
+++ b/argo-cd-apps/overlays/internal-staging/dummy-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: dummy-deployment
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/dummy-deployment
+          environment: ""
+  template:
+    metadata:
+      name: dummy-deployment-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-dummy-deploy
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/internal-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/internal-staging/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd-local
 resources:
   - ../../base/all-clusters
   - ../../base/internal
+  - dummy-deployment.yaml
 patches:
   - path: environment-patch.yaml
     target:

--- a/components/dummy-deployment/OWNERS
+++ b/components/dummy-deployment/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+
+- psturc
+- p8r-the-gr8
+- flacatus
+- enkeefe00

--- a/components/dummy-deployment/base/kustomization.yaml
+++ b/components/dummy-deployment/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - name: dummy-deployment-config
+    namespace: konflux-dummy-deploy
+    literals:
+      - DISPLAY_TEXT=Hello from Dummy Deployment!
+    options:
+      disableNameSuffixHash: true

--- a/components/dummy-deployment/external-staging/kustomization.yaml
+++ b/components/dummy-deployment/external-staging/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - https://github.com/flacatus/konflux-dummy-deploy//k8s?ref=dc87f05445031d218b6b66a583513d051ce0ef84
+images:
+  - name: quay.io/redhat-appstudio-qe/dummy-deployment
+    newTag: dc87f05445031d218b6b66a583513d051ce0ef84
+patches:
+  - target:
+      kind: ConfigMap
+      name: dummy-deployment-config
+    patch: |
+      - op: replace
+        path: /data/DISPLAY_TEXT
+        value: "Hello from EXTERNAL STAGING!"

--- a/components/dummy-deployment/internal-staging/kustomization.yaml
+++ b/components/dummy-deployment/internal-staging/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - https://github.com/flacatus/konflux-dummy-deploy//k8s?ref=dc87f05445031d218b6b66a583513d051ce0ef84
+images:
+  - name: quay.io/redhat-appstudio-qe/dummy-deployment
+    newTag: dc87f05445031d218b6b66a583513d051ce0ef84
+patches:
+  - target:
+      kind: ConfigMap
+      name: dummy-deployment-config
+    patch: |
+      - op: replace
+        path: /data/DISPLAY_TEXT
+        value: "Hello from INTERNAL STAGING!"


### PR DESCRIPTION
In order to test https://docs.kargo.io/operator-guide/architecture#distributed-configuration Argocd + Kargo we need a dummy component