### PR TITLE
feat(konflux-devlake): enforce SSL for database connection in staging

### DIFF
--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -46,6 +46,8 @@ lake:
     # - More API calls but avoids timeouts and missing data
     GITHUB_GRAPHQL_JOB_COLLECTION_MODE: "PAGINATING"
     GITHUB_GRAPHQL_JOB_PAGINATING_PAGE_SIZE: "100"
+
+    DB_URL: "mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_SERVER):$(MYSQL_PORT)/$(MYSQL_DATABASE)?charset=$(DB_CHARSET)&parseTime=$(DB_PARSE_TIME)&loc=$(DB_LOCATION)&tls=true"
   volumes:
     - name: trusted-ca
       configMap:


### PR DESCRIPTION
## Summary
- Adds `DB_URL` environment variable to the DevLake staging Helm values with `tls=true` to enforce SSL for the MySQL database connection
- Connection string references existing secret variables (`MYSQL_USER`, `MYSQL_PASSWORD`, etc.) injected via `envFrom`

## Test plan
- [ ] Verify `kustomize build` succeeds for `internal-staging` overlay
- [ ] Confirm DevLake pod starts and connects to MySQL over SSL in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)