### PR TITLE
fix(konflux-devlake): set SSL_CERT_FILE for staging MySQL TLS

### DIFF
--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -48,6 +48,9 @@ lake:
     GITHUB_GRAPHQL_JOB_PAGINATING_PAGE_SIZE: "100"
 
     DB_URL: "mysql://$(MYSQL_USER):$(MYSQL_PASSWORD)@$(MYSQL_SERVER):$(MYSQL_PORT)/$(MYSQL_DATABASE)?charset=$(DB_CHARSET)&parseTime=$(DB_PARSE_TIME)&loc=$(DB_LOCATION)&tls=true"
+    # Go's crypto/x509 on Debian reads /etc/ssl/certs/ by default, not
+    # /etc/pki/ where OpenShift mounts the trusted CA ConfigMap.
+    SSL_CERT_FILE: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
   volumes:
     - name: trusted-ca
       configMap:


### PR DESCRIPTION
## Summary

- Adds `SSL_CERT_FILE` env var to staging DevLake helm-values so Go's `SystemCertPool()` can find the OpenShift-mounted CA bundle
- The container is Debian-based (`python:3.9-slim-bookworm`), so Go reads `/etc/ssl/certs/` by default — not `/etc/pki/` where OpenShift injects the trusted CA ConfigMap
- `SSL_CERT_FILE` bridges this gap, fixing `x509: certificate signed by unknown authority` errors when connecting to RDS with `tls=true`

## Context

The `DB_URL` already has `tls=true` and the trusted-ca volume is already mounted. The only missing piece was telling Go where to find the CA bundle.

Related devlake changes (gorm.Config bug fix + docker-compose overlay): https://github.com/kpiwko/devlake/tree/feat/devlake-mysql-ssl

## Test plan

- [ ] ArgoCD syncs the staging deployment
- [ ] DevLake pod starts without `x509` or `tls` errors in logs
- [ ] Staging UI loads at the expected URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)