### PR TITLE
Disable Argo Rollouts integration for Kargo shard

### DIFF
--- a/components/kargo-shard-controller/OWNERS
+++ b/components/kargo-shard-controller/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+
+- psturc
+- p8r-the-gr8
+- flacatus

--- a/components/kargo-shard-controller/internal-staging/deployment/kargo-shard-helm-generator.yaml
+++ b/components/kargo-shard-controller/internal-staging/deployment/kargo-shard-helm-generator.yaml
@@ -26,5 +26,7 @@ valuesInline:
     argocd:
       integrationEnabled: true
       namespace: argocd-local
+    argoRollouts:
+      integrationEnabled: false
   kubeconfigSecrets:
     kargo: production-kargo-kubeconfig

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -26,8 +26,8 @@ spec:
           value: https://github.com/redhat-appstudio/infra-common-deployments.git
         - name: component
           value: ${{ ctx.targetFreight.origin.name }}
-        - name: argocdApiUrl
-          value: https://argocd-server.argocd-local.svc.cluster.local
+        # - name: argocdApiUrl
+        #   value: https://argocd-server.argocd-local.svc.cluster.local
       steps:
         - uses: git-clone
           as: clone

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -20,8 +20,8 @@ spec:
           value: https://github.com/redhat-appstudio/infra-common-deployments.git
         - name: component
           value: ${{ ctx.targetFreight.origin.name }}
-        - name: argocdApiUrl
-          value: https://argocd-server.argocd-local.svc.cluster.local
+        # - name: argocdApiUrl
+        #   value: https://argocd-server.argocd-local.svc.cluster.local
       steps:
         - uses: git-clone
           as: clone

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -67,30 +67,31 @@ spec:
           config:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['open-pr'].pr.id }}
+        # TODO: Re-enable once ArgoCD API access is in place (shard controller + token)
         # Workaround for argocd-wait race condition (https://github.com/akuity/kargo/issues/6357)
         # Credit: @cdemarco-drw
         # TODO: Replace with native argocd-wait desiredRevision parameter when upstream implements it
-        - uses: http
-          as: wait-for-argocd-revision
-          retry:
-            timeout: 15m
-          config:
-            method: GET
-            url: ${{ vars.argocdApiUrl }}/api/v1/applications/${{ vars.component }}-in-cluster?appNamespace=argocd-local
-            headers:
-              - name: Authorization
-                value: Bearer ${{ secret('kargo-argocd-token').token }}
-            successExpression: |
-              response.status == 200 &&
-              response.body?.status?.sync?.status == 'Synced' &&
-              response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
-            failureExpression: |
-              response.body?.status?.health?.status == 'Degraded' ||
-              response.body?.status?.operationState?.phase in ['Failed', 'Error']
-            timeout: 60s
-        - uses: argocd-wait
-          as: argocd-wait
-          config:
-            apps:
-              - name: ${{ vars.component }}-in-cluster
-                namespace: argocd-local
+        # - uses: http
+        #   as: wait-for-argocd-revision
+        #   retry:
+        #     timeout: 15m
+        #   config:
+        #     method: GET
+        #     url: ${{ vars.argocdApiUrl }}/api/v1/applications/${{ vars.component }}-in-cluster?appNamespace=argocd-local
+        #     headers:
+        #       - name: Authorization
+        #         value: Bearer ${{ secret('kargo-argocd-token').token }}
+        #     successExpression: |
+        #       response.status == 200 &&
+        #       response.body?.status?.sync?.status == 'Synced' &&
+        #       response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
+        #     failureExpression: |
+        #       response.body?.status?.health?.status == 'Degraded' ||
+        #       response.body?.status?.operationState?.phase in ['Failed', 'Error']
+        #     timeout: 60s
+        # - uses: argocd-wait
+        #   as: argocd-wait
+        #   config:
+        #     apps:
+        #       - name: ${{ vars.component }}-in-cluster
+        #         namespace: argocd-local


### PR DESCRIPTION
Disable Argo Rollouts integration for the Kargo shard as it's not necessary here.
Also comment out some currently unused variables.