### PR TITLE
Add namespace and lease RBAC for shard controller on production

### DIFF
--- a/components/kargo/internal-production/shard-rbac/kustomization.yaml
+++ b/components/kargo/internal-production/shard-rbac/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - serviceaccount.yaml
   - clusterrolebinding.yaml
   - secret.yaml
+  - namespace.yaml
+  - lease-rbac.yaml

--- a/components/kargo/internal-production/shard-rbac/lease-rbac.yaml
+++ b/components/kargo/internal-production/shard-rbac/lease-rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kargo-shard-staging-leases
+  namespace: kargo-shard-staging
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-shard-staging-leases
+  namespace: kargo-shard-staging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kargo-shard-staging-leases
+subjects:
+  - kind: ServiceAccount
+    name: kargo-shard-staging
+    namespace: kargo

--- a/components/kargo/internal-production/shard-rbac/namespace.yaml
+++ b/components/kargo/internal-production/shard-rbac/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kargo-shard-staging


### PR DESCRIPTION
The shard controller manages its heartbeat lease on the production control plane via kubeconfigSecrets.kargo.
This requires the kargo-shard-staging namespace to exist and the SA to have lease permissions there.