### PR TITLE
Restrict shard controller ArgoCD watch to argocd-local namespace

### DIFF
--- a/components/kargo-shard-controller/internal-staging/deployment/kargo-shard-helm-generator.yaml
+++ b/components/kargo-shard-controller/internal-staging/deployment/kargo-shard-helm-generator.yaml
@@ -26,6 +26,7 @@ valuesInline:
     argocd:
       integrationEnabled: true
       namespace: argocd-local
+      watchArgocdNamespaceOnly: true
     rollouts:
       integrationEnabled: false
   kubeconfigSecrets:


### PR DESCRIPTION
Avoids cluster-scope RBAC collision with existing staging Kargo installation.
All Applications reside in argocd-local anyway.