### PR TITLE
Fix shard assignment: use spec.shard instead of label

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -3,11 +3,10 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Stage
 metadata:
   name: ring-1-staging
-  labels:
-    kargo.akuity.io/shard: staging
   annotations:
     kargo.akuity.io/color: yellow
 spec:
+  shard: staging
   requestedFreight:
     - origin:
         kind: Warehouse


### PR DESCRIPTION
Kargo webhook auto-manages kargo.akuity.io/shard label from spec.shard field.
Setting the label directly gets overwritten.