### PR TITLE
Add per-project RBAC for shard controller in kargo-infra-common

### DIFF
--- a/components/kargo/internal-production/shard-rbac/kustomization.yaml
+++ b/components/kargo/internal-production/shard-rbac/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - secret.yaml
   - namespace.yaml
   - lease-rbac.yaml
+  - project-rbac.yaml

--- a/components/kargo/internal-production/shard-rbac/project-rbac.yaml
+++ b/components/kargo/internal-production/shard-rbac/project-rbac.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kargo-shard-staging
+  namespace: kargo-infra-common
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-shard-staging
+  namespace: kargo-infra-common
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kargo-shard-staging
+subjects:
+  - kind: ServiceAccount
+    name: kargo-shard-staging
+    namespace: kargo


### PR DESCRIPTION
Management controller only grants secrets/SA access to the default controller SA.
Shard SA needs explicit Role for git credentials and event recording in project namespaces.