### PR TITLE
Enable argocd-wait step in staging and production promotion templates

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -100,9 +100,9 @@ spec:
         #       response.body?.status?.health?.status == 'Degraded' ||
         #       response.body?.status?.operationState?.phase in ['Failed', 'Error']
         #     timeout: 60s
-        # - uses: argocd-wait
-        #   as: argocd-wait
-        #   config:
-        #     apps:
-        #       - name: ${{ vars.component }}-in-cluster
-        #         namespace: argocd-local
+        - uses: argocd-wait
+          as: argocd-wait
+          config:
+            apps:
+              - name: ${{ vars.component }}-in-cluster
+                namespace: argocd-local

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -89,9 +89,9 @@ spec:
         #       response.body?.status?.health?.status == 'Degraded' ||
         #       response.body?.status?.operationState?.phase in ['Failed', 'Error']
         #     timeout: 60s
-        # - uses: argocd-wait
-        #   as: argocd-wait
-        #   config:
-        #     apps:
-        #       - name: ${{ vars.component }}-in-cluster
-        #         namespace: argocd-local
+        - uses: argocd-wait
+          as: argocd-wait
+          config:
+            apps:
+              - name: ${{ vars.component }}-in-cluster
+                namespace: argocd-local


### PR DESCRIPTION
Shard controller is operational and can access ArgoCD Applications.
Re-enable argocd-wait to block promotions until sync completes and app reports healthy.