### PR TITLE
feat: add sync verification

### DIFF
--- a/argo-cd-apps/base/internal/kargo/appset.yaml
+++ b/argo-cd-apps/base/internal/kargo/appset.yaml
@@ -13,6 +13,8 @@ spec:
   template:
     metadata:
       name: kargo-{{nameNormalized}}
+      annotations:
+        kargo.akuity.io/authorized-stage: kargo-infra-common:ring-1-staging,kargo-infra-common:ring-2-production
     spec:
       project: default
       source:

--- a/argo-cd-apps/base/internal/rover-group-sync/appset.yaml
+++ b/argo-cd-apps/base/internal/rover-group-sync/appset.yaml
@@ -12,6 +12,8 @@ spec:
   template:
     metadata:
       name: rover-group-sync
+      annotations:
+        kargo.akuity.io/authorized-stage: kargo-infra-common:ring-1-staging,kargo-infra-common:ring-2-production
     spec:
       project: default
       source:

--- a/argo-cd-apps/overlays/internal-staging/dummy-deployment.yaml
+++ b/argo-cd-apps/overlays/internal-staging/dummy-deployment.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     metadata:
       name: dummy-deployment-{{nameNormalized}}
+      annotations:
+        kargo.akuity.io/authorized-stage: kargo-infra-common:ring-1-staging
     spec:
       project: default
       source:

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -30,8 +30,6 @@ spec:
           value: https://github.com/redhat-appstudio/infra-common-deployments.git
         - name: component
           value: ${{ ctx.targetFreight.origin.name }}
-        # - name: argocdApiUrl
-        #   value: https://argocd-server.argocd-local.svc.cluster.local
       steps:
         - uses: git-clone
           as: clone
@@ -89,31 +87,12 @@ spec:
           config:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['open-pr'].pr.id }}
-        # TODO: Re-enable once ArgoCD API access is in place (shard controller + token)
-        # Workaround for argocd-wait race condition (https://github.com/akuity/kargo/issues/6357)
-        # Credit: @cdemarco-drw
-        # TODO: Replace with native argocd-wait desiredRevision parameter when upstream implements it
-        # - uses: http
-        #   as: wait-for-argocd-revision
-        #   retry:
-        #     timeout: 15m
-        #   config:
-        #     method: GET
-        #     url: ${{ vars.argocdApiUrl }}/api/v1/applications/${{ vars.component }}-in-cluster?appNamespace=argocd-local
-        #     headers:
-        #       - name: Authorization
-        #         value: Bearer ${{ secret('kargo-argocd-token').token }}
-        #     successExpression: |
-        #       response.status == 200 &&
-        #       response.body?.status?.sync?.status == 'Synced' &&
-        #       response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
-        #     failureExpression: |
-        #       response.body?.status?.health?.status == 'Degraded' ||
-        #       response.body?.status?.operationState?.phase in ['Failed', 'Error']
-        #     timeout: 60s
-        - uses: argocd-wait
-          as: argocd-wait
+        - uses: argocd-update
+          as: argocd-update
           config:
             apps:
               - name: ${{ vars.component }}-in-cluster
                 namespace: argocd-local
+                sources:
+                  - repoURL: ${{ vars.repoURL }}
+                    desiredRevision: ${{ outputs['wait-for-pr'].commit }}

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -26,8 +26,6 @@ spec:
           value: https://github.com/redhat-appstudio/infra-common-deployments.git
         - name: component
           value: ${{ ctx.targetFreight.origin.name }}
-        # - name: argocdApiUrl
-        #   value: https://argocd-server.argocd-local.svc.cluster.local
       steps:
         - uses: git-clone
           as: clone
@@ -79,31 +77,12 @@ spec:
           config:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['open-pr'].pr.id }}
-        # TODO: Re-enable once ArgoCD API access is in place (shard controller + token)
-        # Workaround for argocd-wait race condition (https://github.com/akuity/kargo/issues/6357)
-        # Credit: @cdemarco-drw
-        # TODO: Replace with native argocd-wait desiredRevision parameter when upstream implements it
-        # - uses: http
-        #   as: wait-for-argocd-revision
-        #   retry:
-        #     timeout: 15m
-        #   config:
-        #     method: GET
-        #     url: ${{ vars.argocdApiUrl }}/api/v1/applications/${{ vars.component }}-in-cluster?appNamespace=argocd-local
-        #     headers:
-        #       - name: Authorization
-        #         value: Bearer ${{ secret('kargo-argocd-token').token }}
-        #     successExpression: |
-        #       response.status == 200 &&
-        #       response.body?.status?.sync?.status == 'Synced' &&
-        #       response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
-        #     failureExpression: |
-        #       response.body?.status?.health?.status == 'Degraded' ||
-        #       response.body?.status?.operationState?.phase in ['Failed', 'Error']
-        #     timeout: 60s
-        - uses: argocd-wait
-          as: argocd-wait
+        - uses: argocd-update
+          as: argocd-update
           config:
             apps:
               - name: ${{ vars.component }}-in-cluster
                 namespace: argocd-local
+                sources:
+                  - repoURL: ${{ vars.repoURL }}
+                    desiredRevision: ${{ outputs['wait-for-pr'].commit }}


### PR DESCRIPTION
Uses argocd-update with desiredRevision to ensure that Argo syncs with the desired commit before reporting healthy, preventing premature healthy statuses being reported.

Jira: https://redhat.atlassian.net/browse/KFLUXDP-1045