### PR TITLE
fix: remove argocd-update and uses http for sync verification

### DIFF
--- a/argo-cd-apps/base/internal/kargo/appset.yaml
+++ b/argo-cd-apps/base/internal/kargo/appset.yaml
@@ -13,8 +13,6 @@ spec:
   template:
     metadata:
       name: kargo-{{nameNormalized}}
-      annotations:
-        kargo.akuity.io/authorized-stage: kargo-infra-common:ring-1-staging,kargo-infra-common:ring-2-production
     spec:
       project: default
       source:

--- a/argo-cd-apps/base/internal/rover-group-sync/appset.yaml
+++ b/argo-cd-apps/base/internal/rover-group-sync/appset.yaml
@@ -12,8 +12,6 @@ spec:
   template:
     metadata:
       name: rover-group-sync
-      annotations:
-        kargo.akuity.io/authorized-stage: kargo-infra-common:ring-1-staging,kargo-infra-common:ring-2-production
     spec:
       project: default
       source:

--- a/argo-cd-apps/overlays/internal-staging/dummy-deployment.yaml
+++ b/argo-cd-apps/overlays/internal-staging/dummy-deployment.yaml
@@ -11,8 +11,6 @@ spec:
   template:
     metadata:
       name: dummy-deployment-{{nameNormalized}}
-      annotations:
-        kargo.akuity.io/authorized-stage: kargo-infra-common:ring-1-staging
     spec:
       project: default
       source:

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/argocd-app-reader.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/argocd-app-reader.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-app-reader
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-app-reader-token
+  annotations:
+    kubernetes.io/service-account.name: argocd-app-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kargo-infra-common-argocd-app-reader
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kargo-infra-common-argocd-app-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-infra-common-argocd-app-reader
+subjects:
+  - kind: ServiceAccount
+    name: argocd-app-reader
+    namespace: kargo-infra-common

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - rbac.yaml
+  - argocd-app-reader.yaml

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -106,13 +106,30 @@ spec:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['open-pr'].pr.id }}
             wait: true
-        - uses: argocd-update
+        - uses: http
           if: ${{ status('open-pr') != 'Errored' }}
-          as: argocd-update
+          as: wait-for-revision
+          retry:
+            timeout: 15m
+          config:
+            method: GET
+            url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
+            headers:
+              - name: Authorization
+                value: Bearer ${{ secret('argocd-app-reader-token').token }}
+            insecureSkipTLSVerify: true
+            successExpression: |
+              response.status == 200 &&
+              response.body?.status?.sync?.status == 'Synced' &&
+              response.body?.status?.sync?.revision == '${{ outputs['merge-pr'].commit }}'
+            failureExpression: |
+              response.body?.status?.health?.status == 'Degraded' ||
+              response.body?.status?.operationState?.phase in ['Failed', 'Error']
+            timeout: 60s
+        - uses: argocd-wait
+          if: ${{ status('open-pr') != 'Errored' }}
+          as: argocd-wait
           config:
             apps:
               - name: ${{ vars.component }}-in-cluster
                 namespace: argocd-local
-                sources:
-                  - repoURL: ${{ vars.repoURL }}
-                    desiredRevision: ${{ outputs['merge-pr'].commit }}

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -95,13 +95,30 @@ spec:
           config:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['open-pr'].pr.id }}
-        - uses: argocd-update
+        - uses: http
           if: ${{ status('open-pr') != 'Errored' }}
-          as: argocd-update
+          as: wait-for-revision
+          retry:
+            timeout: 15m
+          config:
+            method: GET
+            url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
+            headers:
+              - name: Authorization
+                value: Bearer ${{ secret('argocd-app-reader-token').token }}
+            insecureSkipTLSVerify: true
+            successExpression: |
+              response.status == 200 &&
+              response.body?.status?.sync?.status == 'Synced' &&
+              response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
+            failureExpression: |
+              response.body?.status?.health?.status == 'Degraded' ||
+              response.body?.status?.operationState?.phase in ['Failed', 'Error']
+            timeout: 60s
+        - uses: argocd-wait
+          if: ${{ status('open-pr') != 'Errored' }}
+          as: argocd-wait
           config:
             apps:
               - name: ${{ vars.component }}-in-cluster
                 namespace: argocd-local
-                sources:
-                  - repoURL: ${{ vars.repoURL }}
-                    desiredRevision: ${{ outputs['wait-for-pr'].commit }}


### PR DESCRIPTION
Replaces argocd-update with a read-only k8s call via http to avoid breaking gitops.

Jira: https://redhat.atlassian.net/browse/KFLUXDP-1045