### PR TITLE
feat(RELDEV-74): Add quay-podman-desktop-oci to production internal s…

### DIFF
--- a/components/internal-services/internal-production/es/es.yaml
+++ b/components/internal-services/internal-production/es/es.yaml
@@ -1214,3 +1214,25 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: signing-artifact-storage-prod
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quay-podman-desktop-oci
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: releng/konflux/rhtap-releng-tenant/private-network/quay-podman-desktop-oci
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: releng-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-podman-desktop-oci

--- a/components/internal-services/internal-production/es/es.yaml
+++ b/components/internal-services/internal-production/es/es.yaml
@@ -1218,7 +1218,7 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: quay-podman-desktop-oci
+  name: quay-internal-oci
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-1"
@@ -1227,7 +1227,7 @@ spec:
     - extract:
         conversionStrategy: Default
         decodingStrategy: None
-        key: releng/konflux/rhtap-releng-tenant/private-network/quay-podman-desktop-oci
+        key: releng/konflux/rhtap-releng-tenant/private-network/quay-internal-oci
   refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
@@ -1235,4 +1235,4 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: quay-podman-desktop-oci
+    name: quay-internal-oci


### PR DESCRIPTION
…ervices.

This secret is used in the sign-and-push-to-internal-oci pipeline, holding a quay robot's username & password to push to a test repo for now.

Signed-off-by: Sean McCarty <semccart@redhat.com>