### PR TITLE
KFLUXINFRA-4171: Configure the infra-deployments staging ArgoCD

### DIFF
--- a/components/argocd-infra-deployments/base/all-application-sets-app.yaml
+++ b/components/argocd-infra-deployments/base/all-application-sets-app.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: all-application-sets-ring-1
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    path: argo-cd-apps/overlays/ring-1
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
+  destination:
+    namespace: argocd-infra-deployments
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/components/argocd-infra-deployments/base/argocd.yaml
+++ b/components/argocd-infra-deployments/base/argocd.yaml
@@ -3,6 +3,8 @@ kind: ArgoCD
 metadata:
     name: argocd-infra-deployments
     namespace: argocd-infra-deployments
+    annotations:
+      argocd.argoproj.io/sync-wave: "0"
 spec:
   kustomizeBuildOptions: "--enable-helm"
   resourceTrackingMethod: annotation

--- a/components/argocd-infra-deployments/base/kustomization.yaml
+++ b/components/argocd-infra-deployments/base/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
   - argocd.yaml
+  - all-application-sets-app.yaml
   - ns.yaml

--- a/components/argocd-infra-deployments/base/ns.yaml
+++ b/components/argocd-infra-deployments/base/ns.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: argocd-infra-deployments
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/components/argocd-infra-deployments/internal-staging/external-secrets/stg-es01-es.yaml
+++ b/components/argocd-infra-deployments/internal-staging/external-secrets/stg-es01-es.yaml
@@ -21,3 +21,10 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: stg-es01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-staging/external-secrets/stg-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-staging/external-secrets/stg-p01-es.yaml
@@ -21,3 +21,10 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: stg-p01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-staging/external-secrets/stg-rh01-es.yaml
+++ b/components/argocd-infra-deployments/internal-staging/external-secrets/stg-rh01-es.yaml
@@ -21,3 +21,10 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: stg-rh01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"


### PR DESCRIPTION
Ensure that only changes to the infra-deployments ArgoCD instance are deployed in-cluster and that ArgoCD appsets from the infra-deployments repo are only deployed to the linked remote clusters. Also add an application that deploys all ArgoCD appsets from the ring-1 overlay in the infra-deployments repo.

Assisted-by: Cursor