### PR TITLE
fix: wait-for-revision can access secrets

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/argocd-app-reader.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/argocd-app-reader.yaml
@@ -3,11 +3,15 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argocd-app-reader
+  namespace: kargo-shared-resources
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: argocd-app-reader-token
+  namespace: kargo-shared-resources
+  labels:
+    kargo.akuity.io/cred-type: generic
   annotations:
     kubernetes.io/service-account.name: argocd-app-reader
 type: kubernetes.io/service-account-token
@@ -35,4 +39,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: argocd-app-reader
-    namespace: kargo-infra-common
+    namespace: kargo-shared-resources

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -106,30 +106,31 @@ spec:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['open-pr'].pr.id }}
             wait: true
-        # - uses: http
-        #   if: ${{ status('open-pr') != 'Errored' }}
-        #   as: wait-for-revision
-        #   retry:
-        #     timeout: 15m
-        #   config:
-        #     method: GET
-        #     url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
-        #     headers:
-        #       - name: Authorization
-        #         value: Bearer ${{ secret('argocd-app-reader-token').token }}
-        #     insecureSkipTLSVerify: true
-        #     successExpression: |
-        #       response.status == 200 &&
-        #       response.body?.status?.sync?.status == 'Synced' &&
-        #       response.body?.status?.sync?.revision == '${{ outputs['merge-pr'].commit }}'
-        #     failureExpression: |
-        #       response.body?.status?.health?.status == 'Degraded' ||
-        #       response.body?.status?.operationState?.phase in ['Failed', 'Error']
-        #     timeout: 60s
-        # - uses: argocd-wait
-        #   if: ${{ status('open-pr') != 'Errored' }}
-        #   as: argocd-wait
-        #   config:
-        #     apps:
-        #       - name: ${{ vars.component }}-in-cluster
-        #         namespace: argocd-local
+        - uses: http
+          if: ${{ status('open-pr') != 'Errored' }}
+          as: wait-for-revision
+          retry:
+            timeout: 15m
+          config:
+            method: GET
+            url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
+            headers:
+              - name: Authorization
+                value: Bearer ${{ sharedSecret('argocd-app-reader-token').token }}
+            insecureSkipTLSVerify: true
+            successExpression: |
+              response.status == 200 &&
+              response.body?.status?.sync?.status == 'Synced' &&
+              response.body?.status?.sync?.revision == '${{ outputs['merge-pr'].commit }}'
+            failureExpression: |
+              response.status == 200 &&
+              (response.body?.status?.health?.status == 'Degraded' ||
+              response.body?.status?.operationState?.phase in ['Failed', 'Error'])
+            timeout: 60s
+        - uses: argocd-wait
+          if: ${{ status('open-pr') != 'Errored' }}
+          as: argocd-wait
+          config:
+            apps:
+              - name: ${{ vars.component }}-in-cluster
+                namespace: argocd-local

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -95,30 +95,31 @@ spec:
           config:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['open-pr'].pr.id }}
-        # - uses: http
-        #   if: ${{ status('open-pr') != 'Errored' }}
-        #   as: wait-for-revision
-        #   retry:
-        #     timeout: 15m
-        #   config:
-        #     method: GET
-        #     url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
-        #     headers:
-        #       - name: Authorization
-        #         value: Bearer ${{ secret('argocd-app-reader-token').token }}
-        #     insecureSkipTLSVerify: true
-        #     successExpression: |
-        #       response.status == 200 &&
-        #       response.body?.status?.sync?.status == 'Synced' &&
-        #       response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
-        #     failureExpression: |
-        #       response.body?.status?.health?.status == 'Degraded' ||
-        #       response.body?.status?.operationState?.phase in ['Failed', 'Error']
-        #     timeout: 60s
-        # - uses: argocd-wait
-        #   if: ${{ status('open-pr') != 'Errored' }}
-        #   as: argocd-wait
-        #   config:
-        #     apps:
-        #       - name: ${{ vars.component }}-in-cluster
-        #         namespace: argocd-local
+        - uses: http
+          if: ${{ status('open-pr') != 'Errored' }}
+          as: wait-for-revision
+          retry:
+            timeout: 15m
+          config:
+            method: GET
+            url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
+            headers:
+              - name: Authorization
+                value: Bearer ${{ sharedSecret('argocd-app-reader-token').token }}
+            insecureSkipTLSVerify: true
+            successExpression: |
+              response.status == 200 &&
+              response.body?.status?.sync?.status == 'Synced' &&
+              response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
+            failureExpression: |
+              response.status == 200 &&
+              (response.body?.status?.health?.status == 'Degraded' ||
+              response.body?.status?.operationState?.phase in ['Failed', 'Error'])
+            timeout: 60s
+        - uses: argocd-wait
+          if: ${{ status('open-pr') != 'Errored' }}
+          as: argocd-wait
+          config:
+            apps:
+              - name: ${{ vars.component }}-in-cluster
+                namespace: argocd-local


### PR DESCRIPTION
Fixes wait-for-revision http step failing due to secret permissions and fixes failureExpression to actually check it can access Argo

Jira: https://redhat.atlassian.net/browse/KFLUXDP-1045