### PR TITLE
KFLUXINFRA-4168: Create infra-deployments prod ArgoCD instance

### DIFF
--- a/components/argocd-infra-deployments/all-application-sets/base/all-application-sets-app.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/base/all-application-sets-app.yaml
@@ -1,13 +1,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: all-application-sets-ring-1
+  name: all-application-sets
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
   project: default
   source:
-    path: argo-cd-apps/overlays/ring-1
+    path: argo-cd-apps/overlays/base # To be replaced in ring overlays with patches
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
     targetRevision: main
   destination:

--- a/components/argocd-infra-deployments/all-application-sets/base/kustomization.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/base/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - argocd.yaml
-  - ns.yaml
+  - all-application-sets-app.yaml

--- a/components/argocd-infra-deployments/all-application-sets/ring-1/kustomization.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-1/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd-infra-deployments
+resources:
+  - ../base
+patches:
+  - path: patches/source-path-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets
+  # Name patch must be last to avoid conflicts with the App name being changed
+  - path: patches/name-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets

--- a/components/argocd-infra-deployments/all-application-sets/ring-1/patches/name-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-1/patches/name-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /metadata/name
+  value: all-application-sets-ring-1

--- a/components/argocd-infra-deployments/all-application-sets/ring-1/patches/source-path-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-1/patches/source-path-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/source/path
+  value: argo-cd-apps/overlays/ring-1

--- a/components/argocd-infra-deployments/all-application-sets/ring-2/kustomization.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-2/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd-infra-deployments
+resources:
+  - ../base
+patches:
+  - path: patches/source-path-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets
+  # Name patch must be last to avoid conflicts with the App name being changed
+  - path: patches/name-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets

--- a/components/argocd-infra-deployments/all-application-sets/ring-2/patches/name-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-2/patches/name-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /metadata/name
+  value: all-application-sets-ring-2

--- a/components/argocd-infra-deployments/all-application-sets/ring-2/patches/source-path-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-2/patches/source-path-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/source/path
+  value: argo-cd-apps/overlays/ring-2

--- a/components/argocd-infra-deployments/all-application-sets/ring-3/kustomization.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-3/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd-infra-deployments
+resources:
+  - ../base
+patches:
+  - path: patches/source-path-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets
+  # Name patch must be last to avoid conflicts with the App name being changed
+  - path: patches/name-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets

--- a/components/argocd-infra-deployments/all-application-sets/ring-3/patches/name-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-3/patches/name-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /metadata/name
+  value: all-application-sets-ring-3

--- a/components/argocd-infra-deployments/all-application-sets/ring-3/patches/source-path-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-3/patches/source-path-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/source/path
+  value: argo-cd-apps/overlays/ring-3

--- a/components/argocd-infra-deployments/all-application-sets/ring-4/kustomization.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-4/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd-infra-deployments
+resources:
+  - ../base
+patches:
+  - path: patches/source-path-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets
+  # Name patch must be last to avoid conflicts with the App name being changed
+  - path: patches/name-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets

--- a/components/argocd-infra-deployments/all-application-sets/ring-4/patches/name-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-4/patches/name-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /metadata/name
+  value: all-application-sets-ring-4

--- a/components/argocd-infra-deployments/all-application-sets/ring-4/patches/source-path-patch.yaml
+++ b/components/argocd-infra-deployments/all-application-sets/ring-4/patches/source-path-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/source/path
+  value: argo-cd-apps/overlays/ring-4

--- a/components/argocd-infra-deployments/internal-production/external-secrets/fedora-01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/fedora-01-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: fedora-01-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/terraform/generated/kflux-fedora-01/kflux-fedora-01
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: fedora-01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/kustomization.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd-infra-deployments
+
+resources:
+  - prd-p01-es.yaml
+  - prd-p02-es.yaml
+  - prd-rh01-es.yaml
+  - prd-rh02-es.yaml
+  - prd-rh03-es.yaml
+  - prd-es01-es.yaml
+  - ocp-p01-es.yaml
+  - rhel-p01-es.yaml
+  - osp-p01-es.yaml
+  - fedora-01-es.yaml
+  - redhat-appstudio-es.yaml

--- a/components/argocd-infra-deployments/internal-production/external-secrets/ocp-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/ocp-p01-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ocp-p01-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/kflux-ocp-p01
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ocp-p01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/osp-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/osp-p01-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: osp-p01-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/terraform/generated/kflux-osp-p01/kflux-osp-p01
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: osp-p01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-es01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-es01-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prd-es01-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/kflux-prd-es01
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: prd-es01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-p01-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prd-p01-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/stone-prod-p01
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: prd-p01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-p02-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-p02-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prd-p02-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/stone-prod-p02
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: prd-p02-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh01-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prd-rh01-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/stone-prd-rh01
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: prd-rh01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh02-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh02-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prd-rh02-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/kflux-prd-rh02
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: prd-rh02-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh03-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh03-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prd-rh03-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/terraform/generated/kflux-prd-rh03/kflux-prd-rh03
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: prd-rh03-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/redhat-appstudio-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/redhat-appstudio-es.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redhat-appstudio-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: repo-creds
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/infrastructure/github-argocd/argocd-infra-deployments-production-redhat-appstudio
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: redhat-appstudio-secret

--- a/components/argocd-infra-deployments/internal-production/external-secrets/rhel-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/rhel-p01-es.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rhel-p01-es
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/platform/terraform/generated/kflux-rhel-p01/kflux-rhel-p01
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rhel-p01-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          appstudio.redhat.com/is-tenant-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/kustomization.yaml
+++ b/components/argocd-infra-deployments/internal-production/kustomization.yaml
@@ -1,3 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: [] # Not yet deployed to production
+resources:
+  - ../base
+  - ../all-application-sets/ring-2
+  - ../all-application-sets/ring-3
+  - ../all-application-sets/ring-4
+  - external-secrets
+
+patches:
+    - path: patches/argocd-controller-replicas-patch.yaml
+      target:
+        group: argoproj.io
+        version: v1beta1
+        kind: ArgoCD

--- a/components/argocd-infra-deployments/internal-production/patches/argocd-controller-replicas-patch.yaml
+++ b/components/argocd-infra-deployments/internal-production/patches/argocd-controller-replicas-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/controller/replicas
+  value: 10

--- a/components/argocd-infra-deployments/internal-staging/kustomization.yaml
+++ b/components/argocd-infra-deployments/internal-staging/kustomization.yaml
@@ -4,4 +4,5 @@ namespace: argocd-infra-deployments
 
 resources:
   - ../base
+  - ../all-application-sets/ring-1
   - external-secrets


### PR DESCRIPTION
This commit creates the infra-deployments prod ArgoCD instance and adds the external secrets for the production clusters.