### PR TITLE
Deploy Kargo shard for infra-deployments-staging

### DIFF
--- a/argo-cd-apps/overlays/internal-staging/kargo-shard-infra-deployments.yaml
+++ b/argo-cd-apps/overlays/internal-staging/kargo-shard-infra-deployments.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kargo-shard-infra-deployments
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/kargo-shard
+          environment: ""
+  template:
+    metadata:
+      name: kargo-shard-infra-deployments-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/infra-deployments'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: kargo-shard-infra-deployments
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true

--- a/argo-cd-apps/overlays/internal-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/internal-staging/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../base/internal
   - dummy-deployment.yaml
   - kargo-shard-infra-common-deployments.yaml
-
+  - kargo-shard-infra-deployments.yaml
 patches:
   - path: environment-patch.yaml
     target:

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -42,3 +42,4 @@ spec:
         - kargo-infra-deployments
         - kargo-shared-resources
         - kargo-shard-infra-common-deployments
+        - kargo-shard-infra-deployments

--- a/components/kargo-shard/internal-staging/infra-deployments/deployment/kargo-shard-helm-generator.yaml
+++ b/components/kargo-shard/internal-staging/infra-deployments/deployment/kargo-shard-helm-generator.yaml
@@ -1,0 +1,48 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: kargo-shard-infra-deployments
+name: kargo
+repo: oci://ghcr.io/akuity/kargo-charts
+version: 1.10.7
+namespace: kargo-shard-infra-deployments
+releaseName: kargo-shard-infra-deployments
+valuesInline:
+  image:
+    repository: quay.io/konflux-ci/kargo
+    tag: 1.10-2cd30bc
+  # Controller-only shard: full Kargo on this cluster owns the data plane
+  # (CRDs, ClusterRoles, webhooks, shared namespaces). Avoid SharedResourceWarning.
+  api:
+    enabled: false
+  webhooksServer:
+    enabled: false
+  externalWebhooksServer:
+    enabled: false
+  garbageCollector:
+    enabled: false
+  managementController:
+    enabled: false
+  webhooks:
+    register: false
+  crds:
+    install: false
+  rbac:
+    installClusterRoles: false
+    installClusterRoleBindings: false
+  global:
+    createClusterSecretsNamespace: false
+    systemResources:
+      createNamespace: false
+    sharedResources:
+      createNamespace: false
+  controller:
+    shardName: infra-deployments-staging
+    argocd:
+      integrationEnabled: true
+      namespace: argocd-infra-deployments
+      watchArgocdNamespaceOnly: true
+    rollouts:
+      integrationEnabled: false
+  kubeconfigSecrets:
+    kargo: production-kargo-kubeconfig

--- a/components/kargo-shard/internal-staging/infra-deployments/deployment/kustomization.yaml
+++ b/components/kargo-shard/internal-staging/infra-deployments/deployment/kustomization.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+  - kargo-shard-helm-generator.yaml
+
+# One patch entry per resource — multi-doc $patch: delete via path panics in kustomize.
+patches:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-cluster-secrets-admin
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-cluster-secrets-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-cluster-secrets-reader
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-cluster-secrets-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-cluster-secrets-admin
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-cluster-secrets-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-cluster-secrets-reader
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-cluster-secrets-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-shared-resources-admin
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-shared-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-shared-resources-reader
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-shared-resources-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-shared-resources-admin
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-shared-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-shared-resources-reader
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-shared-resources-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-system-resources-admin
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-system-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-system-resources-reader
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-system-resources-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-system-resources-admin
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-system-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-system-resources-reader
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-system-resources-reader

--- a/components/kargo-shard/internal-staging/infra-deployments/external-secrets/kubeconfig-secret.yaml
+++ b/components/kargo-shard/internal-staging/infra-deployments/external-secrets/kubeconfig-secret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: production-kargo-kubeconfig
+  namespace: kargo-shard-infra-deployments
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: production-kargo-kubeconfig
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/devprod/kargo-shard-kubeconfig

--- a/components/kargo-shard/internal-staging/infra-deployments/external-secrets/kustomization.yaml
+++ b/components/kargo-shard/internal-staging/infra-deployments/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kubeconfig-secret.yaml

--- a/components/kargo-shard/internal-staging/infra-deployments/kustomization.yaml
+++ b/components/kargo-shard/internal-staging/infra-deployments/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - external-secrets
+  - deployment

--- a/components/kargo-shard/internal-staging/infra-deployments/namespace.yaml
+++ b/components/kargo-shard/internal-staging/infra-deployments/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kargo-shard-infra-deployments

--- a/components/kargo/internal-production/shard-rbac/infra-deployments/staging/kustomization.yaml
+++ b/components/kargo/internal-production/shard-rbac/infra-deployments/staging/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - role.yaml
+  - rolebinding.yaml

--- a/components/kargo/internal-production/shard-rbac/infra-deployments/staging/namespace.yaml
+++ b/components/kargo/internal-production/shard-rbac/infra-deployments/staging/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kargo-shard-infra-deployments

--- a/components/kargo/internal-production/shard-rbac/infra-deployments/staging/role.yaml
+++ b/components/kargo/internal-production/shard-rbac/infra-deployments/staging/role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kargo-shard-infra-deployments-leases
+  namespace: kargo-shard-infra-deployments
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update

--- a/components/kargo/internal-production/shard-rbac/infra-deployments/staging/rolebinding.yaml
+++ b/components/kargo/internal-production/shard-rbac/infra-deployments/staging/rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-shard-infra-deployments-leases
+  namespace: kargo-shard-infra-deployments
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kargo-shard-infra-deployments-leases
+subjects:
+  - kind: ServiceAccount
+    name: kargo-shard-staging
+    namespace: kargo

--- a/components/kargo/internal-production/shard-rbac/kustomization.yaml
+++ b/components/kargo/internal-production/shard-rbac/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - lease-rbac.yaml
   - project-rbac.yaml
   - external-secret.yaml
+  - infra-deployments/staging


### PR DESCRIPTION
Add a second Kargo shard controller on internal-staging that watches the argocd-infra-deployments ArgoCD instance and phones home to the full Kargo install on common-internal-production, reusing the existing kargo-shard-staging identity and kubeconfig Vault secret.