### PR TITLE
fix: successExpression checks history for healthy sync

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -125,12 +125,13 @@ spec:
             url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
             headers:
               - name: Authorization
-                value: Bearer ${{ sharedSecret('argocd-app-reader-token').token }}
+                value: Bearer ${{ secret('argocd-app-reader-token').token }}
             insecureSkipTLSVerify: true
             successExpression: |
               response.status == 200 &&
               response.body?.status?.sync?.status == 'Synced' &&
-              response.body?.status?.sync?.revision == '${{ outputs['merge-pr'].commit }}'
+              response.body?.status?.health?.status == 'Healthy' &&
+              any(response.body.status.history, {.revision == '${{ outputs['merge-pr'].commit }}'})
             failureExpression: |
               response.status == 200 &&
               (response.body?.status?.health?.status == 'Degraded' ||

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -105,12 +105,13 @@ spec:
             url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
             headers:
               - name: Authorization
-                value: Bearer ${{ sharedSecret('argocd-app-reader-token').token }}
+                value: Bearer ${{ secret('argocd-app-reader-token').token }}
             insecureSkipTLSVerify: true
             successExpression: |
               response.status == 200 &&
               response.body?.status?.sync?.status == 'Synced' &&
-              response.body?.status?.sync?.revision == '${{ outputs['wait-for-pr'].commit }}'
+              response.body?.status?.health?.status == 'Healthy' &&
+              any(response.body.status.history, {.revision == '${{ outputs['wait-for-pr'].commit }}'})
             failureExpression: |
               response.status == 200 &&
               (response.body?.status?.health?.status == 'Degraded' ||


### PR DESCRIPTION
SuccessExpression checks the history for the healthy commit instead of getting stuck.