### PR TITLE
KFLUXINFRA-4168: Fix ArgoCD controller replicas patch

### DIFF
--- a/components/argocd-infra-deployments/internal-production/patches/argocd-controller-replicas-patch.yaml
+++ b/components/argocd-infra-deployments/internal-production/patches/argocd-controller-replicas-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
-  path: /spec/controller/replicas
+  path: /spec/controller/sharding/replicas
   value: 10


### PR DESCRIPTION
The path to the replicas field was incorrect and did not update the correct field.