### PR TITLE
Add TektonConfig resource to internal-staging

### DIFF
--- a/components/openshift-pipelines/internal-staging/kustomization.yaml
+++ b/components/openshift-pipelines/internal-staging/kustomization.yaml
@@ -2,11 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  # Base resources
   - ../base
-
-patches:
-  - path: tekton-config-patch.yaml
-    target:
-      kind: TektonConfig
-      name: config
+  - tekton-config.yaml

--- a/components/openshift-pipelines/internal-staging/tekton-config-patch.yaml
+++ b/components/openshift-pipelines/internal-staging/tekton-config-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonConfig
-metadata:
-  name: config
-spec:
-  result:
-    disabled: true

--- a/components/openshift-pipelines/internal-staging/tekton-config.yaml
+++ b/components/openshift-pipelines/internal-staging/tekton-config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  results:
+    disabled: true


### PR DESCRIPTION
## What

- Convert the TektonConfig from a no-op kustomize patch to a standalone resource in `internal-staging`
- This makes `results.disabled: true` actually take effect

Environments affected: internal-staging

## Why

The previous `tekton-config-patch.yaml` was a kustomize strategic merge patch targeting `TektonConfig/config`, but no base TektonConfig resource existed in the kustomization — so the patch was silently skipped and `results.disabled` never took effect.

## Validation

- `kustomize build` passes for all four overlays


Made with [Cursor](https://cursor.com)