### PR TITLE
Configure Tekton resolver retry and imagepullbackoff timeout

### DIFF
--- a/components/openshift-pipelines/internal-staging/kustomization.yaml
+++ b/components/openshift-pipelines/internal-staging/kustomization.yaml
@@ -2,11 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  # Base resources
   - ../base
-
-patches:
-  - path: tekton-config-patch.yaml
-    target:
-      kind: TektonConfig
-      name: config
+  - tekton-config.yaml

--- a/components/openshift-pipelines/internal-staging/tekton-config-patch.yaml
+++ b/components/openshift-pipelines/internal-staging/tekton-config-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonConfig
-metadata:
-  name: config
-spec:
-  result:
-    disabled: true

--- a/components/openshift-pipelines/internal-staging/tekton-config.yaml
+++ b/components/openshift-pipelines/internal-staging/tekton-config.yaml
@@ -7,5 +7,21 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "1"
 spec:
+  pipeline:
+    options:
+      configMaps:
+        config-defaults:
+          data:
+            default-imagepullbackoff-timeout: "15m"
+        bundleresolver-config:
+          data:
+            fetch-timeout: "2m"
+            backoff-duration: "15s"
+            backoff-factor: "2.0"
+            backoff-steps: "10"
+            backoff-cap: "15m"
+        git-resolver-config:
+          data:
+            fetch-timeout: "2m"
   results:
     disabled: true

--- a/components/openshift-pipelines/internal-staging/tekton-config.yaml
+++ b/components/openshift-pipelines/internal-staging/tekton-config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  results:
+    disabled: true


### PR DESCRIPTION
## What

- Set `default-imagepullbackoff-timeout` to 15m in `config-defaults`
- Configure bundle resolver retry with exponential back-off (~15 min)
- Configure git resolver fetch timeout (2m)

Environments affected: internal-staging

[KONFLUX-14907](https://redhat.atlassian.net/browse/KONFLUX-14907)

## Why

Tekton bundle and git resolvers fail immediately on transient errors (OCI registry outages, GitHub/GitLab rate limiting). Retry with exponential back-off makes pipeline resolution resilient to these transient failures without requiring manual re-runs. Mirrors infra-deployments PRs [#12976](https://github.com/redhat-appstudio/infra-deployments/pull/12976) and [#13006](https://github.com/redhat-appstudio/infra-deployments/pull/13006).

## Validation

- `kustomize build` passes for all four overlays
- Depends on #580


Made with [Cursor](https://cursor.com)

[KONFLUX-14907]: https://redhat.atlassian.net/browse/KONFLUX-14907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ