### PR TITLE
fix: checks if sync advanced

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -118,6 +118,20 @@ spec:
             mergeMethod: squash
         - uses: http
           if: ${{ status('open-pr') != 'Errored' }}
+          as: get-current-revision
+          config:
+            method: GET
+            url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
+            headers:
+              - name: Authorization
+                value: Bearer ${{ secret('argocd-app-reader-token').token }}
+            insecureSkipTLSVerify: true
+            successExpression: response.status == 200
+            outputs:
+              - name: revision
+                fromExpression: response.body.status.sync.revision
+        - uses: http
+          if: ${{ status('open-pr') != 'Errored' }}
           as: wait-for-revision
           retry:
             timeout: 15m
@@ -131,7 +145,10 @@ spec:
             successExpression: |
               response.status == 200 &&
               response.body?.status?.sync?.status == 'Synced' &&
-              any(response.body.status.history, {.revision == '${{ outputs['merge-pr'].commit }}'})
+              (
+                any(response.body.status.history, {.revision == '${{ outputs['merge-pr'].commit }}'}) ||
+                response.body?.status?.sync?.revision != '${{ outputs['get-current-revision'].revision }}'
+              )
             failureExpression: |
               response.status == 200 &&
               (response.body?.status?.health?.status == 'Degraded' ||

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -97,6 +97,20 @@ spec:
             prNumber: ${{ outputs['open-pr'].pr.id }}
         - uses: http
           if: ${{ status('open-pr') != 'Errored' }}
+          as: get-current-revision
+          config:
+            method: GET
+            url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster
+            headers:
+              - name: Authorization
+                value: Bearer ${{ secret('argocd-app-reader-token').token }}
+            insecureSkipTLSVerify: true
+            successExpression: response.status == 200
+            outputs:
+              - name: revision
+                fromExpression: response.body.status.sync.revision
+        - uses: http
+          if: ${{ status('open-pr') != 'Errored' }}
           as: wait-for-revision
           retry:
             timeout: 15m
@@ -110,7 +124,10 @@ spec:
             successExpression: |
               response.status == 200 &&
               response.body?.status?.sync?.status == 'Synced' &&
-              any(response.body.status.history, {.revision == '${{ outputs['wait-for-pr'].commit }}'})
+              (
+                any(response.body.status.history, {.revision == '${{ outputs['wait-for-pr'].commit }}'}) ||
+                response.body?.status?.sync?.revision != '${{ outputs['get-current-revision'].revision }}'
+              )
             failureExpression: |
               response.status == 200 &&
               (response.body?.status?.health?.status == 'Degraded' ||


### PR DESCRIPTION
Uses get-current-revision to check if Argo has advanced from it's original sync. An OR operator in wait-for-revision checks for the freight commit or if Argo has advanced it's sync status from the original sync. Tested locally and this seemed to have work.