### PR TITLE
Add permissions to konflux-admins for Argo Apps

### DIFF
--- a/components/iam/base/konflux-admins.yaml
+++ b/components/iam/base/konflux-admins.yaml
@@ -381,6 +381,17 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applicationsets
+      - applications
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This adds permissions to the konflux-admins role to allow it to manage Argo Applications and ApplicationSets.