### PR TITLE
Create an spre-automations namespaces

### DIFF
--- a/argo-cd-apps/base/internal/kustomization.yaml
+++ b/argo-cd-apps/base/internal/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - policies
   - rover-group-sync
   - kueue
+  - spre-automations

--- a/argo-cd-apps/base/internal/spre-automations/appset.yaml
+++ b/argo-cd-apps/base/internal/spre-automations/appset.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: spre-automations
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/spre-automations
+          environment: ""
+  template:
+    metadata:
+      name: spre-automations-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/internal/spre-automations/kustomization.yaml
+++ b/argo-cd-apps/base/internal/spre-automations/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- appset.yaml

--- a/argo-cd-apps/overlays/internal-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/internal-staging/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../base/internal
   - dummy-deployment.yaml
   - kargo-shard-controller.yaml
+
 patches:
   - path: environment-patch.yaml
     target:

--- a/components/rover-group-sync/base/config/ldap-sync-config.yaml
+++ b/components/rover-group-sync/base/config/ldap-sync-config.yaml
@@ -20,7 +20,7 @@ rfc2307:
     baseDN: "ou=adhoc,ou=managedGroups,dc=redhat,dc=com"
     derefAliases: never
     scope: sub
-    filter: '(&(objectClass=rhatRoverGroup)(|(cn=konflux-admins)(cn=konflux-build)(cn=konflux-build-admins)(cn=konflux-contributors)(cn=konflux-cost-management-admins)(cn=konflux-devprod)(cn=konflux-ec)(cn=konflux-grafana-viewers)(cn=konflux-infra)(cn=konflux-integration)(cn=konflux-kubearchive)(cn=konflux-migration)(cn=konflux-mintmaker-team)(cn=konflux-o11y)(cn=konflux-o11y-admins)(cn=konflux-performance)(cn=konflux-pipeline-service)(cn=konflux-qe)(cn=konflux-qe-admins)(cn=konflux-release-team)(cn=konflux-sre)(cn=konflux-support)(cn=konflux-support-ops)(cn=konflux-ui)(cn=konflux-vanguard)(cn=ai-konflux-user-support)(cn=plm-poe)(cn=test-platform-ci-admins)))'
+    filter: '(&(objectClass=rhatRoverGroup)(|(cn=konflux-admins)(cn=konflux-build)(cn=konflux-build-admins)(cn=konflux-contributors)(cn=konflux-cost-management-admins)(cn=konflux-devprod)(cn=konflux-ec)(cn=konflux-grafana-viewers)(cn=konflux-infra)(cn=konflux-integration)(cn=konflux-kubearchive)(cn=konflux-migration)(cn=konflux-mintmaker-team)(cn=konflux-o11y)(cn=konflux-o11y-admins)(cn=konflux-performance)(cn=konflux-pipeline-service)(cn=konflux-qe)(cn=konflux-qe-admins)(cn=konflux-release-team)(cn=konflux-sre)(cn=konflux-support)(cn=konflux-support-ops)(cn=konflux-ui)(cn=konflux-vanguard)(cn=ai-konflux-user-support)(cn=plm-poe)(cn=sp-resilience-team)(cn=test-platform-ci-admins)))'
   groupUIDAttribute: dn
   groupNameAttributes:
     - cn

--- a/components/spre-automations/OWNERS
+++ b/components/spre-automations/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+  - geored
+
+reviewers:
+  - geored

--- a/components/spre-automations/base/kustomization.yaml
+++ b/components/spre-automations/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: spre-automations
+
+resources:
+- namespace.yaml
+- rbac

--- a/components/spre-automations/base/namespace.yaml
+++ b/components/spre-automations/base/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spre-automations

--- a/components/spre-automations/base/rbac/kustomization.yaml
+++ b/components/spre-automations/base/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - spre-automations-viewers.yaml

--- a/components/spre-automations/base/rbac/spre-automations-viewers.yaml
+++ b/components/spre-automations/base/rbac/spre-automations-viewers.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spre-automations-viewers
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: sp-resilience-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view

--- a/components/spre-automations/internal-production/kustomization.yaml
+++ b/components/spre-automations/internal-production/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/spre-automations/internal-staging/kustomization.yaml
+++ b/components/spre-automations/internal-staging/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
Create an empty NS on both internal staging and prod with rbac allowing people in sp-resilience-team rover group to be able to view content on NS.

Also add sp-resilience-team to the list of groups to sync from rover.

[KFLUXINFRA-4226](https://redhat.atlassian.net/browse/KFLUXINFRA-4226)

[KFLUXINFRA-4226]: https://redhat.atlassian.net/browse/KFLUXINFRA-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ