### PR TITLE
Onboard authentication to kargo-infra-deployments

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - promotiontasks
+  - warehouse.yaml

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/promotiontasks/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/promotiontasks/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - manifest-pt.yaml

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/promotiontasks/manifest-pt.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/promotiontasks/manifest-pt.yaml
@@ -1,0 +1,37 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: PromotionTask
+metadata:
+  name: authentication-manifest-promote
+spec:
+  vars:
+    - name: component
+      value: authentication
+    - name: ring
+    - name: srcPath
+  steps:
+    - uses: yaml-parse
+      as: get-kustomize-resources
+      if: ${{ ctx.targetFreight.origin.name == "authentication-manifest-wh" }}
+      config:
+        path: ./${{ vars.srcPath }}/components/${{ vars.component }}/rings/${{ vars.ring }}/base/kustomization.yaml
+        outputs:
+        - name: kustomizeResources
+          fromExpression: resources
+
+    - uses: yaml-parse
+      as: get-base-resource-index
+      if: ${{ ctx.targetFreight.origin.name == "authentication-manifest-wh" }}
+      config:
+        path: ./${{ vars.srcPath }}/components/${{ vars.component }}/rings/${{ vars.ring }}/base/kustomization.yaml
+        outputs:
+        - name: baseResourceIndex
+          fromExpression: "findIndex(${{ task.outputs['get-kustomize-resources'].kustomizeResources }}, # == '../../../base')"
+
+    - uses: yaml-update
+      as: promote-new-base
+      if: ${{ ctx.targetFreight.origin.name == "authentication-manifest-wh" }}
+      config:
+        path: ./${{ vars.srcPath }}/components/${{ vars.component }}/rings/${{ vars.ring }}/base/kustomization.yaml
+        updates:
+          - key: "resources.${{ task.outputs['get-base-resource-index'].baseResourceIndex }}"
+            value: ../../../new-base

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/warehouse.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/warehouse.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: authentication-manifest-wh
+spec:
+  freightCreationPolicy: Automatic
+  interval: 2h0m0s
+  subscriptions:
+  - git:
+      repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+      commitSelectionStrategy: NewestFromBranch
+      branch: main
+      includePaths:
+        - 'components/authentication/new-base'

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/base/stage-ring-1.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/base/stage-ring-1.yaml
@@ -13,6 +13,11 @@ spec:
       sources:
         stages:
           - ring-0-dummy-deployment
+    - origin:
+        kind: Warehouse
+        name: authentication-manifest-wh
+      sources:
+        direct: true
   promotionTemplate:
     spec:
       vars:
@@ -34,12 +39,20 @@ spec:
           vars:
             - name: srcPath
               value: ./src
+        - task:
+            name: authentication-manifest-promote
+          as: authentication-manifest-promote
+          vars:
+            - name: srcPath
+              value: ./src
+            - name: ring
+              value: ring-1
         - uses: git-commit
           as: commit
           config:
             path: ./src
             message: |
-              chore(${{ ctx.stage }}): promote ${{ vars.component }}
+              chore(${{ ctx.stage }}): promote ${{ vars.component }} to ring-1
         - uses: git-push
           as: push
           config:
@@ -53,7 +66,7 @@ spec:
             repoURL: ${{ vars.repoURL }}
             sourceBranch: ${{ ctx.project }}/${{ vars.component }}/ring-1
             targetBranch: main
-            title: "chore(${{ ctx.stage }}): promote ${{ vars.component }}"
+            title: "chore(${{ ctx.stage }}): promote ${{ vars.component }} to ring-1"
             description: |
               ### ${{ ctx.stage }}
 

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - base
   - dummy-deployment
   - konflux-operator
+  - authentication
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
Adds the `components/authentication/` folder of infra-deployments as a warehouse linked to the Ring 1 stage of kargo-infra-deployments. Also adds a ring-generic promotion task for the authentication manifests.