### PR TITLE
Fix all-application-sets-app name collision

### DIFF
--- a/components/argocd-infra-deployments/base/all-application-sets-app.yaml
+++ b/components/argocd-infra-deployments/base/all-application-sets-app.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: all-application-sets
+  name: infra-deployments-all-application-sets
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:

--- a/components/argocd-infra-deployments/internal-production/kustomization.yaml
+++ b/components/argocd-infra-deployments/internal-production/kustomization.yaml
@@ -15,4 +15,4 @@ patches:
         group: argoproj.io
         version: v1alpha1
         kind: Application
-        name: all-application-sets
+        name: infra-deployments-all-application-sets


### PR DESCRIPTION
The name "all-application-sets" was used in both the "all-infra-deployments-application-sets" and "all-application-sets" applications. This commit changes the name of the "all-application-sets" application to "all-infra-deployments-application-sets".