### PR TITLE
fix(kargo): stop shard from owning shared cluster resources on staging

### DIFF
--- a/components/kargo-shard-controller/internal-staging/deployment/kargo-shard-helm-generator.yaml
+++ b/components/kargo-shard-controller/internal-staging/deployment/kargo-shard-helm-generator.yaml
@@ -11,16 +11,31 @@ valuesInline:
   image:
     repository: quay.io/konflux-ci/kargo
     tag: 1.10-2cd30bc
+  # Controller-only shard: full Kargo on this cluster owns the data plane
+  # (CRDs, ClusterRoles, webhooks, shared namespaces). Avoid SharedResourceWarning.
   api:
     enabled: false
-  webhooks:
+  webhooksServer:
+    enabled: false
+  externalWebhooksServer:
     enabled: false
   garbageCollector:
     enabled: false
   managementController:
     enabled: false
-  dex:
-    enabled: false
+  webhooks:
+    register: false
+  crds:
+    install: false
+  rbac:
+    installClusterRoles: false
+    installClusterRoleBindings: false
+  global:
+    createClusterSecretsNamespace: false
+    systemResources:
+      createNamespace: false
+    sharedResources:
+      createNamespace: false
   controller:
     shardName: staging
     argocd:

--- a/components/kargo-shard-controller/internal-staging/deployment/kustomization.yaml
+++ b/components/kargo-shard-controller/internal-staging/deployment/kustomization.yaml
@@ -4,3 +4,150 @@ kind: Kustomization
 
 generators:
   - kargo-shard-helm-generator.yaml
+
+# One patch entry per resource — multi-doc $patch: delete via path panics in kustomize.
+patches:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-cluster-secrets-admin
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-cluster-secrets-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-cluster-secrets-reader
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-cluster-secrets-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-cluster-secrets-admin
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-cluster-secrets-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-cluster-secrets-reader
+      namespace: kargo-cluster-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-cluster-secrets-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-shared-resources-admin
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-shared-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-shared-resources-reader
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-shared-resources-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-shared-resources-admin
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-shared-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-shared-resources-reader
+      namespace: kargo-shared-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-shared-resources-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-system-resources-admin
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-system-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: kargo-system-resources-reader
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: kargo-system-resources-reader
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-system-resources-admin
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-system-resources-admin
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: kargo-system-resources-reader
+      namespace: kargo-system-resources
+    patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kargo-system-resources-reader


### PR DESCRIPTION
Make the staging shard controller-only so it no longer conflicts with the full Kargo install on the same cluster (Argo CD SharedResourceWarning).