### PR TITLE
Fix authentication Kargo promotion

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/promotiontasks/manifest-pt.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/authentication/promotiontasks/manifest-pt.yaml
@@ -24,7 +24,7 @@ spec:
         path: ./${{ vars.srcPath }}/components/${{ vars.component }}/rings/${{ vars.ring }}/base/kustomization.yaml
         outputs:
         - name: baseResourceIndex
-          fromExpression: "findIndex(${{ task.outputs['get-kustomize-resources'].kustomizeResources }}, # == '../../../base')"
+          fromExpression: "quote(findIndex(outputs['get-kustomize-resources'].kustomizeResources, # == '../../../base'))"
 
     - uses: yaml-update
       as: promote-new-base


### PR DESCRIPTION
Change the baseResourceIndex expression to quote the index so that it can be used as a key in the yaml-update step.