### PR TITLE
Fix production kargo stage always out of sync

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-1-staging.yaml
@@ -109,7 +109,7 @@ spec:
           if: ${{ status('open-pr') != 'Errored' }}
           as: merge-pr
           retry:
-            timeout: 2h
+            timeout: 2h0m0s
             errorThreshold: 240
           config:
             repoURL: ${{ vars.repoURL }}
@@ -120,7 +120,7 @@ spec:
           if: ${{ status('open-pr') != 'Errored' }}
           as: wait-for-revision
           retry:
-            timeout: 15m
+            timeout: 15m0s
           config:
             method: GET
             url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/stage-ring-2-production.yaml
@@ -99,7 +99,7 @@ spec:
           if: ${{ status('open-pr') != 'Errored' }}
           as: wait-for-revision
           retry:
-            timeout: 15m
+            timeout: 15m0s
           config:
             method: GET
             url: https://kubernetes.default.svc/apis/argoproj.io/v1alpha1/namespaces/argocd-local/applications/${{ vars.component }}-in-cluster

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/base/stage-ring-1.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/base/stage-ring-1.yaml
@@ -107,7 +107,7 @@ spec:
         - uses: http
           as: find-pr
           retry:
-            timeout: 5m
+            timeout: 5m0s
             errorThreshold: 10
           config:
             method: GET
@@ -125,7 +125,7 @@ spec:
         - uses: git-merge-pr
           as: merge-pr
           retry:
-            timeout: 2h
+            timeout: 2h0m0s
           config:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['find-pr'].prNumber }}

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/dummy-deployment/stage-ring-0-dummy-deployment.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/dummy-deployment/stage-ring-0-dummy-deployment.yaml
@@ -87,7 +87,7 @@ spec:
         - uses: http
           as: find-pr
           retry:
-            timeout: 5m
+            timeout: 5m0s
             errorThreshold: 10
           config:
             method: GET
@@ -105,7 +105,7 @@ spec:
         - uses: git-merge-pr
           as: merge-pr
           retry:
-            timeout: 2h
+            timeout: 2h0m0s
           config:
             repoURL: ${{ vars.repoURL }}
             prNumber: ${{ outputs['find-pr'].prNumber }}

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/konflux-operator/stage-ring-0-konflux-operator.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/konflux-operator/stage-ring-0-konflux-operator.yaml
@@ -87,7 +87,7 @@ spec:
         - uses: http
           as: find-pr
           retry:
-            timeout: 5m
+            timeout: 5m0s
             errorThreshold: 10
           config:
             method: GET
@@ -105,7 +105,7 @@ spec:
         - uses: git-merge-pr
           as: merge-pr
           retry:
-            timeout: 2h
+            timeout: 2h0m0s
             errorThreshold: 240
           config:
             repoURL: ${{ vars.repoURL }}


### PR DESCRIPTION
The live manifests have all the way up to seconds precision but the manifests in git do not explicitly configure minutes and seconds. This is causing ArgoCD to always see them as out of sync.