### PR TITLE
Fix shard lease RBAC after rename to infra-common-deployments

### DIFF
--- a/components/kargo/internal-production/shard-rbac/lease-rbac.yaml
+++ b/components/kargo/internal-production/shard-rbac/lease-rbac.yaml
@@ -2,8 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kargo-shard-staging-leases
-  namespace: kargo-shard-staging
+  name: kargo-shard-infra-common-deployments-leases
+  namespace: kargo-shard-infra-common-deployments
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -17,12 +17,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kargo-shard-staging-leases
-  namespace: kargo-shard-staging
+  name: kargo-shard-infra-common-deployments-leases
+  namespace: kargo-shard-infra-common-deployments
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kargo-shard-staging-leases
+  name: kargo-shard-infra-common-deployments-leases
 subjects:
   - kind: ServiceAccount
     name: kargo-shard-staging

--- a/components/kargo/internal-production/shard-rbac/namespace.yaml
+++ b/components/kargo/internal-production/shard-rbac/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kargo-shard-staging
+  name: kargo-shard-infra-common-deployments


### PR DESCRIPTION
Heartbeat renewals target the renamed namespace; grant lease access there so the staging shard can renew on production.