### PR TITLE
chore: Lower signing server limits

### DIFF
--- a/components/kueue/internal-production/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-production/queue-config/cluster-queue.yaml
@@ -26,5 +26,5 @@ spec:
       - name: tekton.dev/pipelineruns
         nominalQuota: '500'
       - name: signing-server-request
-        nominalQuota: '500'
+        nominalQuota: '50'
   stopPolicy: None

--- a/components/kueue/internal-staging/queue-config/cluster-queue.yaml
+++ b/components/kueue/internal-staging/queue-config/cluster-queue.yaml
@@ -26,5 +26,5 @@ spec:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
       - name: signing-server-request
-        nominalQuota: '300'
+        nominalQuota: '25'
   stopPolicy: None


### PR DESCRIPTION
Upon request by the signing server team, and as this feature will start to be used, we want to start with a safe number and gradually increase as we watch the traffic go in. 

The math behind these new numbers:
- every pipeline with a signing task has 8 workers that can dispatch requests in parallel
- the kueue limits the number of pipelines, on production this means 50*8=400 concurrent requests to signing server

That should be plenty to preserve konflux release ability while maintaing a safe number for signing server. This value should go up once we verify that signing server can keep up with the demand.