### PR TITLE
fix(konflux-devlake): stop injecting RDS CA bundle as env on staging

### DIFF
--- a/components/konflux-devlake/internal-staging/external-secrets/konflux-devlake-rds-ca.yaml
+++ b/components/konflux-devlake/internal-staging/external-secrets/konflux-devlake-rds-ca.yaml
@@ -1,0 +1,28 @@
+---
+# Large CA bundles must be mounted as files, not injected as env vars.
+# Linux rejects exec when any single env value exceeds MAX_ARG_STRLEN (128KiB);
+# the AWS RDS global bundle is ~165KiB and caused:
+#   exec container process `/usr/bin/tini`: Argument list too long
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: konflux-devlake-rds-ca
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  data:
+    - secretKey: AWS_RDS_CRTS
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/qe/konflux-devlake
+        property: AWS_RDS_CRTS
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: konflux-devlake-rds-ca

--- a/components/konflux-devlake/internal-staging/external-secrets/konflux-devlake-secrets.yaml
+++ b/components/konflux-devlake/internal-staging/external-secrets/konflux-devlake-secrets.yaml
@@ -20,3 +20,15 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: konflux-devlake-secrets
+    # Drop AWS_RDS_CRTS from the env-injected secret. That PEM is synced
+    # separately into konflux-devlake-rds-ca and mounted as a file.
+    template:
+      engineVersion: v2
+      templateFrom:
+        - target: Data
+          literal: |
+            {{- range $k, $v := . }}
+            {{- if ne $k "AWS_RDS_CRTS" }}
+            {{ $k }}: {{ $v | toJson }}
+            {{- end }}
+            {{- end }}

--- a/components/konflux-devlake/internal-staging/external-secrets/kustomization.yaml
+++ b/components/konflux-devlake/internal-staging/external-secrets/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - konflux-devlake-secrets.yaml
+  - konflux-devlake-rds-ca.yaml

--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -58,9 +58,10 @@ lake:
         items:
           - key: ca-bundle.crt
             path: tls-ca-bundle.pem
+    # File mount only — do not put AWS_RDS_CRTS into envFrom (exceeds 128KiB).
     - name: rds-ca
       secret:
-        secretName: konflux-devlake-secrets
+        secretName: konflux-devlake-rds-ca
         items:
           - key: AWS_RDS_CRTS
             path: rds-ca-bundle.pem


### PR DESCRIPTION
AWS_RDS_CRTS exceeds Linux MAX_ARG_STRLEN (128KiB), so envFrom of konflux-devlake-secrets made the lake pod fail with: exec container process `/usr/bin/tini`: Argument list too long

Mount the PEM from a dedicated secret instead, and exclude it from the env-injected ExternalSecret.