### PR TITLE
KFLUXSPRT-8487: unify RHEL Jira bot API keys

### DIFF
--- a/components/konflux-support-ops/base/deployment.yaml
+++ b/components/konflux-support-ops/base/deployment.yaml
@@ -44,26 +44,16 @@ spec:
             secretKeyRef:
               name: konflux-support-ops-secrets
               key: JIRA_API_KEY
-        - name: JIRA_API_KEY_CKI
+        - name: JIRA_API_KEY_RHEL
           valueFrom:
             secretKeyRef:
               name: konflux-support-ops-secrets
-              key: JIRA_API_KEY_CKI
+              key: JIRA_API_KEY_RHEL
         - name: JIRA_API_KEY_KONFLUX
           valueFrom:
             secretKeyRef:
               name: konflux-support-ops-secrets
               key: JIRA_API_KEY_KONFLUX
-        - name: JIRA_API_KEY_SP_RHEL
-          valueFrom:
-            secretKeyRef:
-              name: konflux-support-ops-secrets
-              key: JIRA_API_KEY_SP_RHEL
-        - name: JIRA_API_KEY_OSCI
-          valueFrom:
-            secretKeyRef:
-              name: konflux-support-ops-secrets
-              key: JIRA_API_KEY_OSCI
         - name: JIRA_API_KEY_OPENSHIFT_PIPELINES
           valueFrom:
             secretKeyRef:

--- a/components/konflux-support-ops/base/deployment.yaml
+++ b/components/konflux-support-ops/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
           defaultMode: 420
       containers:
       - name: support-ops
-        image: quay.io/redhat-user-workloads/konflux-user-support-tenant/chat-bot/user-support@sha256:32e9628433fa61f4dfe45d6bc6f3b8817b6c3fc609dc99ac778b6e11130bb2d7
+        image: quay.io/redhat-user-workloads/konflux-user-support-tenant/chat-bot/user-support@sha256:9325cadbf873fefe353295a2691d8850053c0b38aaae45031d93de7e6bdb7377
         imagePullPolicy: Always
         env:
         - name: PYTHONPATH
@@ -101,11 +101,11 @@ spec:
           readOnly: true
         resources:
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            cpu: 100m
-            memory: 256Mi
+            cpu: 1000m
+            memory: 1Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## What

Replace three separate RHEL project bot env vars (`JIRA_API_KEY_CKI`, `JIRA_API_KEY_SP_RHEL`, `JIRA_API_KEY_OSCI`) with a single `JIRA_API_KEY_RHEL` for the unified `rhel-pipeline-sre-bot-user`.

Environments affected: internal-staging, internal-production

[KFLUXSPRT-8487](https://redhat.atlassian.net/browse/KFLUXSPRT-8487)

## Why

Consolidating three RHEL project bots into one as requested by RHEL Pipeline SRE team.

## Validation

- `kustomize build` passes for base, internal-staging, internal-production

[KFLUXSPRT-8487]: https://redhat.atlassian.net/browse/KFLUXSPRT-8487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ