### PR TITLE
Segment bridge key vault production

### DIFF
--- a/argo-cd-apps/base/all-clusters/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - monitoring-workload-blackbox
   - monitoring-workload-logging
   - monitoring-workload-prometheus
+  - segment-bridge

--- a/argo-cd-apps/base/all-clusters/segment-bridge/appset.yaml
+++ b/argo-cd-apps/base/all-clusters/segment-bridge/appset.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: segment-bridge
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/segment-bridge
+          environment: ""
+  template:
+    metadata:
+      name: segment-bridge-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: segment-bridge
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/all-clusters/segment-bridge/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/segment-bridge/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset.yaml

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -43,3 +43,4 @@ spec:
         - kargo-shared-resources
         - kargo-shard-infra-common-deployments
         - kargo-shard-infra-deployments
+        - segment-bridge

--- a/components/segment-bridge/OWNERS
+++ b/components/segment-bridge/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- Omeramsc
+- hguemar
+- ShakedAviv50313
+- shacharFridman
+- Shiri-sh
+
+reviewers:
+- Omeramsc
+- hguemar
+- ShakedAviv50313
+- shacharFridman
+- Shiri-sh

--- a/components/segment-bridge/external-production/external-secrets/kustomization.yaml
+++ b/components/segment-bridge/external-production/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - segment-write-key.yaml

--- a/components/segment-bridge/external-production/external-secrets/segment-write-key.yaml
+++ b/components/segment-bridge/external-production/external-secrets/segment-write-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: segment-write-key
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/service-enhancement/segment-write-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    name: segment-write-key
+    creationPolicy: Owner
+    deletionPolicy: Delete

--- a/components/segment-bridge/external-production/kustomization.yaml
+++ b/components/segment-bridge/external-production/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secrets
+
+namespace: segment-bridge

--- a/components/segment-bridge/external-staging/external-secrets/kustomization.yaml
+++ b/components/segment-bridge/external-staging/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - segment-write-key.yaml

--- a/components/segment-bridge/external-staging/external-secrets/segment-write-key.yaml
+++ b/components/segment-bridge/external-staging/external-secrets/segment-write-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: segment-write-key
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/service-enhancement/segment-write-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    name: segment-write-key
+    creationPolicy: Owner
+    deletionPolicy: Delete

--- a/components/segment-bridge/external-staging/kustomization.yaml
+++ b/components/segment-bridge/external-staging/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secrets
+
+namespace: segment-bridge

--- a/components/segment-bridge/internal-production/external-secrets/kustomization.yaml
+++ b/components/segment-bridge/internal-production/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - segment-write-key.yaml

--- a/components/segment-bridge/internal-production/external-secrets/segment-write-key.yaml
+++ b/components/segment-bridge/internal-production/external-secrets/segment-write-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: segment-write-key
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: production/service-enhancement/segment-write-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    name: segment-write-key
+    creationPolicy: Owner
+    deletionPolicy: Delete

--- a/components/segment-bridge/internal-production/kustomization.yaml
+++ b/components/segment-bridge/internal-production/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secrets
+
+namespace: segment-bridge

--- a/components/segment-bridge/internal-staging/external-secrets/kustomization.yaml
+++ b/components/segment-bridge/internal-staging/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - segment-write-key.yaml

--- a/components/segment-bridge/internal-staging/external-secrets/segment-write-key.yaml
+++ b/components/segment-bridge/internal-staging/external-secrets/segment-write-key.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: segment-write-key
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/service-enhancement/segment-write-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    name: segment-write-key
+    creationPolicy: Owner
+    deletionPolicy: Delete

--- a/components/segment-bridge/internal-staging/kustomization.yaml
+++ b/components/segment-bridge/internal-staging/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secrets
+
+namespace: segment-bridge


### PR DESCRIPTION
Follow-up to the staging rollout: deploys the segment-write-key
ExternalSecret on the two production clusters (external-production and
internal-production) so ESO creates a segment-write-key Secret from
the production/service-enhancement/segment-write-key Vault path, mirroring
the staging setup that was validated first.
