### PR TITLE
chore: Gate Argo CD health on Konflux CR readiness

### DIFF
--- a/components/argocd-infra-deployments/base/argocd.yaml
+++ b/components/argocd-infra-deployments/base/argocd.yaml
@@ -86,6 +86,35 @@ spec:
 
           return health_status
   resourceHealthChecks:
+  - group: konflux.konflux-ci.dev
+    kind: Konflux
+    check: |
+      hs = {}
+      if obj.status == nil or obj.status.conditions == nil then
+        hs.status = "Progressing"
+        hs.message = "Waiting for Konflux status"
+        return hs
+      end
+      for i, condition in ipairs(obj.status.conditions) do
+        if condition.type == "Ready" then
+          if condition.status == "True" then
+            hs.status = "Healthy"
+            hs.message = condition.message
+            return hs
+          end
+          if condition.reason == "ComponentsNotReady" then
+            hs.status = "Progressing"
+            hs.message = condition.message
+            return hs
+          end
+          hs.status = "Degraded"
+          hs.message = condition.message
+          return hs
+        end
+      end
+      hs.status = "Progressing"
+      hs.message = "Ready condition not reported yet"
+      return hs
   - group: logging.openshift.io
     kind: ClusterLogForwarder
     check: |


### PR DESCRIPTION
Without this check, Applications syncing a Konflux CR report Healthy as soon as the object exists, even while components are still rolling out. Mirror the development-operator overlay so common-cluster ArgoCD reflects Ready status.

Assisted-by: Cursor