### PR TITLE
Create namespaces for advisories

### DIFF
--- a/argo-cd-apps/base/internal/advisories/appset.yaml
+++ b/argo-cd-apps/base/internal/advisories/appset.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: advisories
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/advisories
+          environment: ""
+  template:
+    metadata:
+      name: advisories-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/internal/advisories/kustomization.yaml
+++ b/argo-cd-apps/base/internal/advisories/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- appset.yaml

--- a/argo-cd-apps/base/internal/kustomization.yaml
+++ b/argo-cd-apps/base/internal/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - advisories
   - argocd-infra-deployments
   - internal-services
   - openshift-pipelines

--- a/components/advisories/OWNERS
+++ b/components/advisories/OWNERS
@@ -1,0 +1,30 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- release-service-bot
+- swickersh
+- querti
+- midnightercz
+
+
+reviewers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- release-service-bot
+- swickersh
+- querti
+- midnightercz

--- a/components/advisories/base/kustomization.yaml
+++ b/components/advisories/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: advisories
+
+resources:
+- namespace.yaml

--- a/components/advisories/base/namespace.yaml
+++ b/components/advisories/base/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: advisories

--- a/components/advisories/internal-production/kustomization.yaml
+++ b/components/advisories/internal-production/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/advisories/internal-staging/kustomization.yaml
+++ b/components/advisories/internal-staging/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
Create an empty namespace on both internal staging and production to host release advisories pipelines.

[KFLUXINFRA-4278](https://redhat.atlassian.net/browse/KFLUXINFRA-4278)

[KFLUXINFRA-4278]: https://redhat.atlassian.net/browse/KFLUXINFRA-4278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ