### PR TITLE
Remove old cluster secret labels

### DIFF
--- a/components/argocd-infra-deployments/internal-production/external-secrets/fedora-01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/fedora-01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "false"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/ocp-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/ocp-p01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/osp-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/osp-p01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-es01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-es01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: eaas
           appstudio.redhat.com/internal-cluster: "false"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-p01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-p02-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-p02-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "true"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "false"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh02-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh02-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "false"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh03-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/prd-rh03-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "false"

--- a/components/argocd-infra-deployments/internal-production/external-secrets/rhel-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-production/external-secrets/rhel-p01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "true"

--- a/components/argocd-infra-deployments/internal-staging/external-secrets/stg-es01-es.yaml
+++ b/components/argocd-infra-deployments/internal-staging/external-secrets/stg-es01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: eaas
           appstudio.redhat.com/internal-cluster: "false"

--- a/components/argocd-infra-deployments/internal-staging/external-secrets/stg-p01-es.yaml
+++ b/components/argocd-infra-deployments/internal-staging/external-secrets/stg-p01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "true"

--- a/components/argocd-infra-deployments/internal-staging/external-secrets/stg-rh01-es.yaml
+++ b/components/argocd-infra-deployments/internal-staging/external-secrets/stg-rh01-es.yaml
@@ -27,6 +27,5 @@ spec:
       metadata:
         labels:
           argocd.argoproj.io/secret-type: cluster
-          appstudio.redhat.com/is-tenant-cluster: "true"
           appstudio.redhat.com/cluster-type: tenant
           appstudio.redhat.com/internal-cluster: "false"


### PR DESCRIPTION
New verifications have been setup in infra-deployments to evaluate other labels current present in the cluster external secrets.