### PR TITLE
chore: Enable konflux-operator auto-promotion from ring-0 to ring-1

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-1-stage.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-1-stage.yaml
@@ -15,6 +15,12 @@ spec:
           - ring-0-dummy-deployment
     - origin:
         kind: Warehouse
+        name: konflux-operator
+      sources:
+        stages:
+          - ring-0-konflux-operator
+    - origin:
+        kind: Warehouse
         name: authentication-manifest-wh
       sources:
         direct: true
@@ -48,6 +54,12 @@ spec:
         - task:
             name: dummy-deployment-promote-ring-1
           as: promote-dummy-deployment
+          vars:
+            - name: srcPath
+              value: ${{ vars.srcPath }}
+        - task:
+            name: konflux-operator-promote-ring-1
+          as: promote-konflux-operator
           vars:
             - name: srcPath
               value: ${{ vars.srcPath }}

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/konflux-operator/promotiontasks/konflux-operator-promote-ring-1.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/konflux-operator/promotiontasks/konflux-operator-promote-ring-1.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: PromotionTask
+metadata:
+  name: konflux-operator-promote-ring-1
+spec:
+  vars:
+    - name: srcPath
+  steps:
+    - uses: yaml-update
+      as: update-konflux-operator
+      if: ${{ ctx.targetFreight.origin.name == "konflux-operator" }}
+      config:
+        path: ${{ vars.srcPath }}/components/konflux-operator/rings/ring-1/base/invariant/kustomization.yaml
+        updates:
+          - key: images.0.newTag
+            value: ${{ imageFrom("quay.io/konflux-ci/konflux-operator").Tag }}
+          - key: resources.0
+            value: https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=${{ imageFrom("quay.io/konflux-ci/konflux-operator").Tag }}

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/konflux-operator/promotiontasks/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/konflux-operator/promotiontasks/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - konflux-operator-promote-ring-0.yaml
+  - konflux-operator-promote-ring-1.yaml


### PR DESCRIPTION
Wire ring-1 to consume verified ring-0 freight and update the ring-1 invariant so staging can track operator versions past development.

Assisted-by: Cursor