### PR TITLE
fix(konflux-devlake): restore staging UI image to a published tag

### DIFF
--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -113,7 +113,7 @@ grafana:
 ui:
   image:
     repository: quay.io/konflux-ci/konflux-devprod/devlake-frontend
-    tag: 9c8f3c56076be1f6e32ff0b08025bed976665cfc
+    tag: 10ee0c7cf0bec845e4397157bc895336adf7dd6b
   securityContext: {}
   containerSecurityContext: {}
   basicAuth:


### PR DESCRIPTION
Restores the staging DevLake UI image to 10ee0c7..., which exists on Quay

The previous tag (9c8f3c...) was never built for the frontend, so the UI pod hit ImagePullBackOff (manifest unknown).