### PR TITLE
fix(kargo): normalize requiredSoakTime to match Kargo's duration format

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-2-stage.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-2-stage.yaml
@@ -13,14 +13,14 @@ spec:
       sources:
         stages:
           - ring-1
-        requiredSoakTime: 24h
+        requiredSoakTime: 24h0m0s
     - origin:
         kind: Warehouse
         name: etcd-shield-manifest-wh
       sources:
         stages:
           - ring-1
-        requiredSoakTime: 24h
+        requiredSoakTime: 24h0m0s
   promotionTemplate:
     spec:
       vars:

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-3-stage.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-3-stage.yaml
@@ -13,14 +13,14 @@ spec:
       sources:
         stages:
           - ring-2
-        requiredSoakTime: 48h
+        requiredSoakTime: 48h0m0s
     - origin:
         kind: Warehouse
         name: etcd-shield-manifest-wh
       sources:
         stages:
           - ring-2
-        requiredSoakTime: 48h
+        requiredSoakTime: 48h0m0s
   promotionTemplate:
     spec:
       vars:

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-4-stage.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/base/stages/ring-4-stage.yaml
@@ -13,14 +13,14 @@ spec:
       sources:
         stages:
           - ring-3
-        requiredSoakTime: 72h
+        requiredSoakTime: 72h0m0s
     - origin:
         kind: Warehouse
         name: etcd-shield-manifest-wh
       sources:
         stages:
           - ring-3
-        requiredSoakTime: 72h
+        requiredSoakTime: 72h0m0s
   promotionTemplate:
     spec:
       vars:


### PR DESCRIPTION
## What

Normalize `requiredSoakTime` values in kargo-infra-deployments Stages
(ring-2, ring-3, ring-4) to explicit duration format with minutes and
seconds precision.

Environments affected: internal-production

## Why

Kargo's controller normalizes durations like `24h` to `24h0m0s` at
runtime. ArgoCD sees this as drift from Git, causing the Stages to be
permanently OutOfSync.

Same fix as #618 for the kargo-infra-deployments project Stages.

## Validation

- `kustomize build argo-cd-apps/overlays/internal-production/` passes

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** None — this is a no-op at runtime, only changes
the string representation to match what Kargo already normalizes to.
**Rollback:** Revert PR