### PR TITLE
bump memory for argocd-infra-deployments server

### DIFF
--- a/components/argocd-infra-deployments/base/argocd.yaml
+++ b/components/argocd-infra-deployments/base/argocd.yaml
@@ -196,7 +196,7 @@ spec:
       enabled: false
     resources:
       limits:
-        memory: 256Mi
+        memory: 512Mi
       requests:
         cpu: 125m
         memory: 128Mi


### PR DESCRIPTION
The Server is getting OOMKilled both in staging and production

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED