### PR TITLE
Update allowed tags for Kargo

### DIFF
--- a/components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/kargo/warehouse.yaml
@@ -15,7 +15,7 @@ spec:
         repoURL: quay.io/konflux-ci/kargo
         imageSelectionStrategy: NewestBuild
         discoveryLimit: 5
-        allowTags: ^1\.10-[0-9a-f]{7}$
+        allowTags: ^1\.(?:1[0-9]+|[2-9][0-9]+)-[0-9a-f]{7}$
     - image:
         repoURL: quay.io/konflux-ci/dex
         imageSelectionStrategy: NewestBuild


### PR DESCRIPTION
Instead of limiting to just 1.10.z releases, follow the same logic as the chart contraint: '1.10.0 <= version < 2.0.0'