### PR TITLE
chore: bump devlake-mcp version in stage

### DIFF
--- a/components/konflux-devlake/internal-staging/kustomization.yaml
+++ b/components/konflux-devlake/internal-staging/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - ../base/oauth2-proxy
 - external-secrets
 - trusted-ca-configmap.yaml
-- https://github.com/konflux-ci/konflux-devlake-mcp.git/k8s?ref=42949ce76227fc1096302c15712eb8b13b7986e4
+- https://github.com/konflux-ci/konflux-devlake-mcp.git/k8s?ref=9295e09d10d53ac8a09e3ea3a4373d3d67e8bbc5
 
 patches:
 - path: configmap-patch.yaml
@@ -26,7 +26,7 @@ helmCharts:
 images:
 - name: quay.io/konflux-ci/konflux-devprod/devlake-mcp-server
   newName: quay.io/konflux-ci/konflux-devprod/devlake-mcp-server
-  newTag: 42949ce76227fc1096302c15712eb8b13b7986e4
+  newTag: 9295e09d10d53ac8a09e3ea3a4373d3d67e8bbc5
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
Updates devlake mcp to the latest HEAD