### PR TITLE
feat(RELEASE-2668): fix ExternalSecret sync-wave deadlock

### DIFF
--- a/components/advisories/internal-staging/es/es.yaml
+++ b/components/advisories/internal-staging/es/es.yaml
@@ -5,7 +5,7 @@ metadata:
   name: advisory-umb-cert
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   dataFrom:
     - extract:
@@ -27,7 +27,7 @@ metadata:
   name: advisory-kafka-creds
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   dataFrom:
     - extract:
@@ -49,7 +49,7 @@ metadata:
   name: advisory-pyxis-stage-cert
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   dataFrom:
     - extract:
@@ -71,7 +71,7 @@ metadata:
   name: gitlab-webhook-config
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   dataFrom:
     - extract:

--- a/components/advisories/internal-staging/repository/advisories-repository.yaml
+++ b/components/advisories/internal-staging/repository/advisories-repository.yaml
@@ -4,6 +4,8 @@ kind: Repository
 metadata:
   name: advisories
   namespace: advisories
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   url: "https://gitlab.cee.redhat.com/redhat-appstudio/advisories"
   git_provider:


### PR DESCRIPTION
## Summary
- The 4 application `ExternalSecrets` for the `advisories` component were in sync-wave `-1`, the same wave as the bootstrap `secret-id` ExternalSecret, but they actually depend on the `konflux-vault` `SecretStore` (wave `0`, unset).
- ArgoCD applies strictly wave-by-wave and won't attempt wave `0` until every wave `-1` resource is Healthy. Since the 4 secrets could never reach Healthy (their Store didn't exist yet), this permanently deadlocked the sync — `SecretStore`, `Task`, and `Repository` never got created at all.
- Moves the 4 application secrets to wave `1`, after the `SecretStore`:
  - wave `-1`: `secret-id` (bootstrap, no dependency on anything in this chain)
  - wave `0`: `SecretStore` (needs the wave `-1` secret)
  - wave `1`: application `ExternalSecrets` (need the `SecretStore`)

## Test plan
- [x] `kustomize build components/advisories/internal-staging` renders cleanly with all 4 secrets at `sync-wave: "1"`
- [ ] Confirm ArgoCD successfully creates `SecretStore`/`Task`/`Repository`/`ExternalSecrets` in the `advisories` namespace after merge
- [ ] Confirm the 4 `ExternalSecrets` report `SecretSynced: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)