### PR TITLE
feat(RELEASE-2668): add release-team RBAC to advisories namespace

### DIFF
--- a/components/advisories/internal-staging/extra/kustomization.yaml
+++ b/components/advisories/internal-staging/extra/kustomization.yaml
@@ -1,11 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: advisories
+
 resources:
-- ../base
-- eso
-- es
-- task
-- repository
-- extra
+  - role.yaml
+  - rolebinding.yaml

--- a/components/advisories/internal-staging/extra/role.yaml
+++ b/components/advisories/internal-staging/extra/role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-team-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list

--- a/components/advisories/internal-staging/extra/rolebinding.yaml
+++ b/components/advisories/internal-staging/extra/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-team-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-team-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-release-team


### PR DESCRIPTION
## Summary

Grants `konflux-release-team` access to `secrets` and `pipelinesascode.tekton.dev/repositories` in the `advisories` namespace, following the same pattern used in `internal-services/internal-staging/extra/`.

Jira: [RELEASE-2668](https://redhat.atlassian.net/browse/RELEASE-2668)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RELEASE-2668]: https://redhat.atlassian.net/browse/RELEASE-2668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ