### PR TITLE
chore: bump devlake-mcp stage version

### DIFF
--- a/components/konflux-devlake/internal-staging/kustomization.yaml
+++ b/components/konflux-devlake/internal-staging/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - ../base/oauth2-proxy
 - external-secrets
 - trusted-ca-configmap.yaml
-- https://github.com/konflux-ci/konflux-devlake-mcp.git/k8s?ref=db602dc7c538ea7918ef78f745535249e566c48b
+- https://github.com/konflux-ci/konflux-devlake-mcp.git/k8s?ref=2ef81cdc62beb8109ffaf90099e314024a91436f
 
 patches:
 - path: configmap-patch.yaml
@@ -26,7 +26,7 @@ helmCharts:
 images:
 - name: quay.io/konflux-ci/konflux-devprod/devlake-mcp-server
   newName: quay.io/konflux-ci/konflux-devprod/devlake-mcp-server
-  newTag: db602dc7c538ea7918ef78f745535249e566c48b
+  newTag: 2ef81cdc62beb8109ffaf90099e314024a91436f
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
This removes the RBAC implementation and makes ssl secret for db connection optional.