### PR TITLE
chore: bump devlake-mcp prod version

### DIFF
--- a/components/konflux-devlake/internal-production/kustomization.yaml
+++ b/components/konflux-devlake/internal-production/kustomization.yaml
@@ -8,10 +8,11 @@ resources:
 - ../base
 - ../base/oauth2-proxy
 - external-secrets
-- https://github.com/konflux-ci/konflux-devlake-mcp.git/k8s?ref=cd87be1563d7d05b00d2e917424b4f6d90c90821
+- https://github.com/konflux-ci/konflux-devlake-mcp.git/k8s?ref=2ef81cdc62beb8109ffaf90099e314024a91436f
 
 patches:
 - path: configmap-patch.yaml
+- path: prod-deployment-patch.yaml
 
 helmCharts:
 - name: devlake
@@ -25,7 +26,7 @@ helmCharts:
 images:
 - name: quay.io/konflux-ci/konflux-devprod/devlake-mcp-server
   newName: quay.io/konflux-ci/konflux-devprod/devlake-mcp-server
-  newTag: cd87be1563d7d05b00d2e917424b4f6d90c90821
+  newTag: 2ef81cdc62beb8109ffaf90099e314024a91436f
 
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "-1"

--- a/components/konflux-devlake/internal-production/prod-deployment-patch.yaml
+++ b/components/konflux-devlake/internal-production/prod-deployment-patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konflux-mcp-server
+  namespace: konflux-devlake
+spec:
+  template:
+    spec:
+      containers:
+        - name: mcp-server
+          env:
+            - name: DB_SSL
+              value: "false"


### PR DESCRIPTION
This includes:
- Work from [KFLUXDP-1100](https://redhat.atlassian.net/browse/KFLUXDP-1100)
- ssl setup for the devlake-db connection (disabled by patch file for now since the secret is not present in prod)

[KFLUXDP-1100]: https://redhat.atlassian.net/browse/KFLUXDP-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ