### PR TITLE
feat(RELEASE-2668): fix advisories Repository CR url

### DIFF
--- a/components/advisories/internal-staging/repository/advisories-repository.yaml
+++ b/components/advisories/internal-staging/repository/advisories-repository.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "2"
 spec:
-  url: "https://gitlab.cee.redhat.com/redhat-appstudio/advisories"
+  url: "https://gitlab.cee.redhat.com/rhtap-release/advisories"
   git_provider:
     url: "https://gitlab.cee.redhat.com"
     secret:


### PR DESCRIPTION
## Summary
- The advisories `Repository` CR's `spec.url` pointed at `gitlab.cee.redhat.com/redhat-appstudio/advisories`, which isn't a real GitLab project — likely a mix-up with the `redhat-appstudio` GitHub org that owns this repo.
- Corrects it to `gitlab.cee.redhat.com/rhtap-release/advisories`, the actual advisories repo used for testing, where the `.tekton/` PipelineRun definition needs to live for PaC to pick it up.

## Test plan
- [x] `kustomize build components/advisories/internal-staging` renders cleanly
- [ ] After merge, confirm the live `Repository` CR in the `advisories` namespace has the corrected `spec.url`
- [ ] Configure the GitLab webhook on `rhtap-release/advisories` and confirm a test push triggers a PipelineRun

🤖 Generated with [Claude Code](https://claude.com/claude-code)