### PR TITLE
feat(RELEASE-2668): populate advisories internal-production

### DIFF
--- a/components/advisories/internal-production/es/es.yaml
+++ b/components/advisories/internal-production/es/es.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: advisory-umb-cert
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: konflux/release/umb/prod/umb-certificates
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: konflux-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: advisory-umb-cert
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: advisory-kafka-creds
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: konflux/release/kafka/stage
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: konflux-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: advisory-kafka-creds
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: advisory-pyxis-stage-cert
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: konflux/release/pyxis/stage
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: konflux-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: advisory-pyxis-stage-cert
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gitlab-webhook-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: konflux/release/gitlab/stage-advisories-webhook-config
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: konflux-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: gitlab-webhook-config

--- a/components/advisories/internal-production/es/kustomization.yaml
+++ b/components/advisories/internal-production/es/kustomization.yaml
@@ -1,11 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: advisories
+
 resources:
-- ../base
-- eso
-- es
-- task
-- repository
-- extra
+  - es.yaml

--- a/components/advisories/internal-production/eso/kustomization.yaml
+++ b/components/advisories/internal-production/eso/kustomization.yaml
@@ -1,11 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: advisories
+
 resources:
-- ../base
-- eso
-- es
-- task
-- repository
-- extra
+  - secret-store.yaml
+  - secret-id.yaml

--- a/components/advisories/internal-production/eso/secret-id.yaml
+++ b/components/advisories/internal-production/eso/secret-id.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: konflux-release-internal-services-vault
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: approles/konflux-release-internal-services-approle
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: konflux-release-internal-services-vault

--- a/components/advisories/internal-production/eso/secret-store.yaml
+++ b/components/advisories/internal-production/eso/secret-store.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: SecretStore
+metadata:
+  name: konflux-vault
+spec:
+  provider:
+    vault:
+      auth:
+        appRole:
+          path: approle
+          roleId: 7ac0afae-d45e-a5d4-d277-d4482efc0cf1
+          secretRef:
+            key: secret_id
+            name: konflux-release-internal-services-vault
+      path: konflux
+      server: 'https://vault.devshift.net'
+      version: v2

--- a/components/advisories/internal-production/extra/kustomization.yaml
+++ b/components/advisories/internal-production/extra/kustomization.yaml
@@ -1,11 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: advisories
+
 resources:
-- ../base
-- eso
-- es
-- task
-- repository
-- extra
+  - role.yaml
+  - rolebinding.yaml

--- a/components/advisories/internal-production/extra/role.yaml
+++ b/components/advisories/internal-production/extra/role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-team-role
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list

--- a/components/advisories/internal-production/extra/rolebinding.yaml
+++ b/components/advisories/internal-production/extra/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-team-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-team-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-release-team

--- a/components/advisories/internal-production/repository/advisories-repository.yaml
+++ b/components/advisories/internal-production/repository/advisories-repository.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: advisories
+  namespace: advisories
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  url: "https://gitlab.cee.redhat.com/rhtap-release/advisories"
+  git_provider:
+    url: "https://gitlab.cee.redhat.com"
+    secret:
+      name: gitlab-webhook-config
+      key: provider.token
+    webhook_secret:
+      name: gitlab-webhook-config
+      key: webhook.secret

--- a/components/advisories/internal-production/repository/kustomization.yaml
+++ b/components/advisories/internal-production/repository/kustomization.yaml
@@ -1,11 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: advisories
+
 resources:
-- ../base
-- eso
-- es
-- task
-- repository
-- extra
+  - advisories-repository.yaml

--- a/components/advisories/internal-production/task/advisory-push-task.yaml
+++ b/components/advisories/internal-production/task/advisory-push-task.yaml
@@ -1,0 +1,348 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: advisory-push
+  namespace: advisories
+spec:
+  description: >-
+    Migrated from GitLab CI push jobs (send-message, update-pyxis-advisory-data).
+    Sends new/updated advisory data to UMB and Kafka, and updates Pyxis.
+  params:
+    - name: repo-url
+      type: string
+    - name: revision
+      type: string
+      description: The commit SHA after the push
+    - name: before-revision
+      type: string
+      description: The commit SHA before the push
+    - name: target-branch
+      type: string
+    - name: umb-env
+      type: string
+      description: Environment passed to amq-producer's -e flag (e.g. stage, prod)
+    - name: umb-topic
+      type: string
+    - name: kafka-topic
+      type: string
+    - name: pyxis-advisory-api
+      type: string
+    - name: pyxis-images-api
+      type: string
+  volumes:
+    - name: repo
+      emptyDir: {}
+    - name: umb-cert
+      secret:
+        secretName: advisory-umb-cert
+    - name: kafka-creds
+      secret:
+        secretName: advisory-kafka-creds
+    - name: pyxis-cert
+      secret:
+        secretName: advisory-pyxis-stage-cert
+  steps:
+    - name: clone
+      image: quay.io/konflux-ci/release-service-utils:fb266c6fa1822d0b417380f286fc4bd149be67c0
+      computeResources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+      volumeMounts:
+        - name: repo
+          mountPath: /workspace/repo
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+
+        # Partial clone: fetches all commit/tree objects (needed for git log/diff)
+        # but defers blob content until something actually reads a file (git show).
+        # Sparse checkout further limits the materialized working tree to .gitlab/,
+        # since advisory files are read on demand via `git show` instead.
+        git clone --filter=blob:none --no-checkout --single-branch \
+          --branch "$(params.target-branch)" "$(params.repo-url)" /workspace/repo
+        cd /workspace/repo
+        git config --global --add safe.directory /workspace/repo
+        git sparse-checkout init --cone
+        git sparse-checkout set .gitlab
+        git checkout "$(params.revision)"
+
+    - name: send-messages
+      image: quay.io/konflux-ci/release-service-utils:fb266c6fa1822d0b417380f286fc4bd149be67c0
+      computeResources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+      volumeMounts:
+        - name: repo
+          mountPath: /workspace/repo
+        - name: umb-cert
+          mountPath: /secrets/umb
+          readOnly: true
+        - name: kafka-creds
+          mountPath: /secrets/kafka
+          readOnly: true
+      env:
+        - name: UMB_ENV
+          value: "$(params.umb-env)"
+        - name: UMB_TOPIC
+          value: "$(params.umb-topic)"
+        - name: UMB_CERT
+          value: /secrets/umb/konflux-release-umb.crt
+        - name: UMB_KEY
+          value: /secrets/umb/konflux-release-umb.key
+        - name: KAFKA_TOPIC
+          value: "$(params.kafka-topic)"
+        - name: KAFKA_USERNAME
+          value: /secrets/kafka/Username
+        - name: KAFKA_PASSWORD
+          value: /secrets/kafka/Password
+        - name: KAFKA_BOOTSTRAP_SERVERS
+          value: /secrets/kafka/BootstrapServers
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+        set -o pipefail
+
+        cd /workspace/repo
+        git config --global --add safe.directory /workspace/repo
+
+        BEFORE="$(params.before-revision)"
+        AFTER="$(params.revision)"
+
+        echo Installing pyyaml and rhmsg...
+        pip install -q pyyaml
+        pip install -q git+https://gitlab.cee.redhat.com/exd-guild-messaging/rhmsg.git
+
+        NEW_ADVISORIES=$(mktemp)
+        UPDATED_ADVISORIES=$(mktemp)
+
+        echo New advisories:
+        git diff --name-only --diff-filter=A "$BEFORE" "$AFTER" \
+          | { grep '^data/advisories/.*/advisory.yaml' || true; } | tee "$NEW_ADVISORIES"
+
+        echo Updated advisories:
+        git diff --name-only --diff-filter=M "$BEFORE" "$AFTER" \
+          | { grep '^data/advisories/.*/advisory.yaml' || true; } | tee "$UPDATED_ADVISORIES"
+
+        if [ ! -s "$NEW_ADVISORIES" ] && [ ! -s "$UPDATED_ADVISORIES" ]; then
+          echo "No new or updated advisories to process, quitting..."
+          exit 0
+        fi
+
+        echo Sending new advisories...
+        for FILE in $(cat "$NEW_ADVISORIES")
+        do
+          echo "  $FILE"
+
+          # Convert advisory yaml to json and set metadata.updated_date to metadata.ship_date
+          JSON_FILE=$(mktemp)
+          git show "$AFTER:$FILE" | yq eval -o=json - | jq -c '.metadata.updated_date = .metadata.ship_date' > "$JSON_FILE"
+
+          # Send message to UMB
+          /tekton/home/.local/bin/amq-producer -e "$UMB_ENV" --certificate-file "$UMB_CERT" --private-key-file "$UMB_KEY" \
+            --property advisory_state=new \
+            --topic "$UMB_TOPIC" --file "$JSON_FILE"
+
+          # Send message to Kafka
+          /home/kafka/producer.py --username-file "$KAFKA_USERNAME" --password-file "$KAFKA_PASSWORD" \
+            --bootstrap-servers-file "$KAFKA_BOOTSTRAP_SERVERS" --header advisory_state=new \
+            --json-file "$JSON_FILE"
+        done
+
+        echo Sending updated advisories...
+        for FILE in $(cat "$UPDATED_ADVISORIES")
+        do
+          echo "  $FILE"
+
+          # Get the date of the last commit that changed this file in the required format
+          UPDATED_DATE=$(git log -1 --date=format:'%Y-%m-%dT%H:%M:%SZ' \
+            --pretty=format:'%ad' "$AFTER" -- "$FILE")
+
+          # Convert advisory yaml to json and set metadata.updated_date to the last commit date
+          JSON_FILE=$(mktemp)
+          git show "$AFTER:$FILE" | yq eval -o=json - \
+            | jq -c --arg updated_date "$UPDATED_DATE" '.metadata.updated_date = $updated_date' > "$JSON_FILE"
+
+          # Get git log of all changes since the file creation and add it to the json.
+          # This relies on the partial clone's on-demand blob fetch to pull in
+          # historical content for `git log -p`.
+          ORIGINAL_COMMIT=$(git log --diff-filter=A --format='%H' "$AFTER" -- "$FILE" | tail -1)
+          GIT_LOG=$(git log -p --no-merges \
+            --format='%h %ad %an <%ae>' --date=iso \
+            --no-show-signature \
+            "$ORIGINAL_COMMIT".."$AFTER" -- "$FILE" \
+            | sed '/^diff --git/d;/^index/d;/^---/d;/^++/d;/^$/d')
+          jq -c --arg git_log "$GIT_LOG" '.metadata.git_log = $git_log' "$JSON_FILE" > "${JSON_FILE}.tmp" && mv "${JSON_FILE}.tmp" "$JSON_FILE"
+
+          # Send message to UMB
+          /tekton/home/.local/bin/amq-producer -e "$UMB_ENV" --certificate-file "$UMB_CERT" --private-key-file "$UMB_KEY" \
+            --property advisory_state=updated \
+            --topic "$UMB_TOPIC" --file "$JSON_FILE"
+
+          # Send message to Kafka
+          /home/kafka/producer.py --username-file "$KAFKA_USERNAME" --password-file "$KAFKA_PASSWORD" \
+            --bootstrap-servers-file "$KAFKA_BOOTSTRAP_SERVERS" --header advisory_state=updated \
+            --json-file "$JSON_FILE"
+        done
+
+    - name: update-pyxis
+      image: quay.io/konflux-ci/release-service-utils:fb266c6fa1822d0b417380f286fc4bd149be67c0
+      computeResources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          memory: 64Mi
+      volumeMounts:
+        - name: repo
+          mountPath: /workspace/repo
+        - name: pyxis-cert
+          mountPath: /secrets/pyxis
+          readOnly: true
+      env:
+        - name: PYXIS_ADVISORY_API
+          value: "$(params.pyxis-advisory-api)"
+        - name: PYXIS_IMAGES_API
+          value: "$(params.pyxis-images-api)"
+        - name: PYXIS_CERT
+          value: /secrets/pyxis/cert
+        - name: PYXIS_KEY
+          value: /secrets/pyxis/key
+      script: |
+        #!/usr/bin/env bash
+        set -eux
+        set -o pipefail
+
+        cd /workspace/repo
+        git config --global --add safe.directory /workspace/repo
+
+        BEFORE="$(params.before-revision)"
+        AFTER="$(params.revision)"
+
+        # TODO: bake this into a dedicated container image instead of inlining it here.
+        # For now it is a straight port of .gitlab/create_redhatcontaineradvisory.sh,
+        # adapted to take a local file path since advisory files aren't checked out
+        # (sparse-checkout excludes data/advisories; content is fetched via `git show`).
+        create_redhatcontaineradvisory() {
+          FILE=$1
+          ID="$(yq '.spec.type' $FILE)-$(yq '.metadata.name' $FILE)"
+          DESCRIPTION="$(yq '.spec.description' $FILE)"
+          SEVERITY="$(yq '.spec.severity // "None"' $FILE)"
+          SHIP_DATE="$(yq '.metadata.ship_date' $FILE)"
+          SOLUTION="$(yq '.spec.solution' $FILE)"
+          SYNOPSIS="$(yq '.spec.synopsis' $FILE)"
+          TOPIC="$(yq '.spec.topic' $FILE)"
+          TYPE="$(yq '.spec.type' $FILE)"
+
+          cves='[]'
+          for CVE in $(yq '.spec.content.images[].cves.fixed | to_entries | .[].key' $FILE | sort -u) ; do
+            cves=$(jq --arg cve "$CVE" \
+              '. += [{"id": $cve, "url": "https://access.redhat.com/security/cve/\($cve)"}]' <<< "$cves")
+          done
+          CVES=$(jq <<< "$cves")
+
+          issues='[]'
+          ISSUES_JSON="$(yq -o=json -I=0 '.spec.issues.fixed' $FILE)"
+          while IFS= read -r ISSUE ; do
+            if [ "$(jq -r '.public' <<< "$ISSUE")" == "false" ] ; then
+              continue
+            fi
+            ISSUE_ID=$(jq -r '.id' <<< "$ISSUE")
+            SOURCE=$(jq -r '.source' <<< "$ISSUE")
+            issues=$(jq --arg id "$ISSUE_ID" --arg source "$SOURCE" \
+              '. += [{"id": $id, "issue_tracker": $source}]' <<< "$issues")
+          done < <(jq -c '.[]' <<< "$ISSUES_JSON")
+          ISSUES=$(jq <<< "$issues")
+
+          jq -n \
+            --arg _id "$ID" \
+            --arg content_type "CONTAINER" \
+            --argjson cves "$CVES" \
+            --arg description "$DESCRIPTION" \
+            --argjson issues "$ISSUES" \
+            --arg severity "$SEVERITY" \
+            --arg ship_date "$SHIP_DATE" \
+            --arg solution "$SOLUTION" \
+            --arg synopsis "$SYNOPSIS" \
+            --arg topic "$TOPIC" \
+            --arg type "$TYPE" \
+            '$ARGS.named'
+        }
+
+        MODIFIED_ADVISORIES=$(mktemp)
+
+        echo New/Updated advisories:
+        git diff --name-only --diff-filter=AM "$BEFORE" "$AFTER" \
+          | { grep '^data/advisories/.*/advisory.yaml' || true; } | tee "$MODIFIED_ADVISORIES"
+
+        if ! [ -s "$MODIFIED_ADVISORIES" ]
+        then
+          echo "No new or updated advisories to process, quitting..."
+          exit 0
+        fi
+
+        RC=0
+        for FILE in $(cat "$MODIFIED_ADVISORIES")
+        do
+          echo "Updating pyxis advisory information for $FILE"
+          git show "$AFTER:$FILE" > /tmp/advisory.yaml
+
+          create_redhatcontaineradvisory /tmp/advisory.yaml > /tmp/payload
+          echo "Creating/updating RedHatContainerAdvisory object"
+          cat /tmp/payload
+          ADVISORY_ID="$(yq '._id' /tmp/payload)"
+
+          # Retry the whole GET-then-branch decision rather than just resending
+          # a single curl request: if a POST/PATCH actually succeeded server-side
+          # but we never saw the response, re-running the GET first will notice
+          # the record now exists and correctly PATCH on the next attempt instead
+          # of blindly resending the same POST.
+          ADVISORY_OK=0
+          for ATTEMPT in 1 2 3; do
+            if curl --key "$PYXIS_KEY" --cert "$PYXIS_CERT" --fail -X GET "${PYXIS_ADVISORY_API}/id/${ADVISORY_ID}" ; then
+              if curl --key "$PYXIS_KEY" --cert "$PYXIS_CERT" --fail-with-body -X PATCH -H 'Content-Type: application/json' --data-binary @/tmp/payload "${PYXIS_ADVISORY_API}/id/${ADVISORY_ID}" ; then
+                ADVISORY_OK=1
+                break
+              fi
+            else
+              if curl --key "$PYXIS_KEY" --cert "$PYXIS_CERT" --fail-with-body -X POST -H 'Content-Type: application/json' --data-binary @/tmp/payload "${PYXIS_ADVISORY_API}" ; then
+                ADVISORY_OK=1
+                break
+              fi
+            fi
+            echo "Attempt $ATTEMPT to create/update advisory $ADVISORY_ID failed, retrying..."
+            sleep 2
+          done
+
+          if [ "$ADVISORY_OK" -ne 1 ]; then
+            echo "Failed to create/update advisory $ADVISORY_ID after 3 attempts"
+            RC=1
+            continue
+          fi
+
+          NUM_IMAGES=$(yq '.spec.content.images | length' /tmp/advisory.yaml)
+          for ((i = 0; i < NUM_IMAGES; i++)); do
+            IMAGE=$(yq '.spec.content.images['$i'].containerImage' /tmp/advisory.yaml)
+            REPOSITORY=$(yq '.spec.content.images['$i'].repository' /tmp/advisory.yaml)
+            REPOSITORY_PATH="${REPOSITORY#*/}"
+            DIGEST="${IMAGE##*@sha256:}"
+            curl --retry 3 --retry-delay 2 --retry-all-errors --key "$PYXIS_KEY" --cert "$PYXIS_CERT" -X GET "${PYXIS_IMAGES_API}?page_size=1&filter=repositories.manifest_schema2_digest%3D%3D%22sha256%3A${DIGEST}%22%3Bnot%28deleted%3D%3Dtrue%29" | jq '.data[0]' > IMAGE.json
+            IMAGE_ID=$(jq -r '._id' IMAGE.json)
+            if [ "$IMAGE_ID" == "null" ] ; then
+              echo "Failed to retrieve pyxis image entry for image with containerImage value $IMAGE"
+              RC=1
+              continue
+            fi
+            jq --arg id "$ADVISORY_ID" --arg repo "$REPOSITORY_PATH" \
+              '(.repositories[] | select(.registry=="registry.access.redhat.com" and .repository==$repo)).image_advisory_id = $id' IMAGE.json > /tmp/IMAGE.json && mv /tmp/IMAGE.json IMAGE.json
+            curl --retry 3 --retry-delay 2 --retry-all-errors --fail-with-body --key "$PYXIS_KEY" --cert "$PYXIS_CERT" -X PATCH -H 'Content-Type: application/json' --data-binary @IMAGE.json "${PYXIS_IMAGES_API}/id/$IMAGE_ID"
+            sleep 0.1
+          done
+        done
+        exit "$RC"

--- a/components/advisories/internal-production/task/kustomization.yaml
+++ b/components/advisories/internal-production/task/kustomization.yaml
@@ -1,11 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: advisories
+
 resources:
-- ../base
-- eso
-- es
-- task
-- repository
-- extra
+  - advisory-push-task.yaml

--- a/components/kueue/internal-production/localqueues/advisories.yaml
+++ b/components/kueue/internal-production/localqueues/advisories.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: advisories
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterQueue: cluster-pipeline-queue

--- a/components/kueue/internal-production/localqueues/kustomization.yaml
+++ b/components/kueue/internal-production/localqueues/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - internal-services.yaml
+- advisories.yaml
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "11"
 


### PR DESCRIPTION
## Summary
- Mirrors the already-merged `internal-staging` advisories setup (Task, Repository, ExternalSecrets, release-team RBAC) into `internal-production`, plus the matching Kueue `LocalQueue`.
- Content is byte-identical to staging (verified via `diff -r`): this still serves the **stage-advisories flow** (same `rhtap-release/advisories` repo, same stage Pyxis/UMB-topic/Kafka-topic, same Vault paths/AppRole) — just deployed to the internal-production cluster as a second environment.
- Real production-advisories work (`releng/advisories` repo, prod Pyxis endpoint, prod UMB/Kafka topics and credentials) is a separate, later effort — not part of this PR.
- Confirmed the Vault AppRole roleId is safe to reuse across clusters (internal-services uses the identical roleId in both its staging and production directories).

## Note
Deploying this does **not** by itself cause duplicate processing of pushes — the `Repository` CR is inert until a GitLab webhook is actually configured to point at this cluster's PaC controller. If a second webhook does get added later, be aware both clusters would then independently process every push (duplicate UMB/Kafka messages, duplicate Pyxis writes) unless that's the intended redundancy.

## Test plan
- [x] `kustomize build components/advisories/internal-production` renders cleanly, all resources resolve to `namespace: advisories`
- [x] `kustomize build components/kueue/internal-production/localqueues` renders cleanly
- [ ] After merge, confirm ArgoCD syncs all resources successfully in the `advisories` namespace on the internal-production cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)