### PR TITLE
PVO11Y-5401 - add owners file for O11Y team to review/approve code under monitoring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@
 # Owners for kargo
 /components/kargo/ @gbenhaim @hugares @enkeefe00
 
+# Owners for monitoring
+/components/monitoring/ @mftb @raks-tt @pacho-rh @martysp21 @TominoFTW @FaisalAl-Rayes @kubasikus @pumahaka @ci-operator
+
 # Owners for openshift-pipelines
 /components/openshift-pipelines/ @scoheb
 

--- a/components/monitoring/OWNERS
+++ b/components/monitoring/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mftb
+- raks-tt
+- pacho-rh
+- martysp21
+- TominoFTW
+- FaisalAl-Rayes
+- kubasikus
+- pumahaka
+- ci-operator


### PR DESCRIPTION
The O11Y team owns the monitoring component; this allows the team to review/approve the code changes we make.  This mirrors the OWNERS file in infra-deployments. 