### PR TITLE
feat: add argocd-app-reader token for kargo-infra-common HTTP step

### DIFF
--- a/components/kargo-shard/internal-staging/infra-common-deployments/argocd-app-reader.yaml
+++ b/components/kargo-shard/internal-staging/infra-common-deployments/argocd-app-reader.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-app-reader
+  namespace: kargo-shard-infra-common-deployments
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-app-reader
+  namespace: argocd-local
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-app-reader
+  namespace: argocd-local
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argocd-app-reader
+subjects:
+  - kind: ServiceAccount
+    name: argocd-app-reader
+    namespace: kargo-shard-infra-common-deployments
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-app-reader-token
+  namespace: kargo-shard-infra-common-deployments
+  annotations:
+    kubernetes.io/service-account.name: argocd-app-reader
+type: kubernetes.io/service-account-token

--- a/components/kargo-shard/internal-staging/infra-common-deployments/kustomization.yaml
+++ b/components/kargo-shard/internal-staging/infra-common-deployments/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - external-secrets
   - deployment
+  - argocd-app-reader.yaml

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/external-secrets/argocd-staging-app-reader-token.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/external-secrets/argocd-staging-app-reader-token.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argocd-staging-app-reader-token
+  namespace: kargo-infra-common
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: argocd-staging-app-reader-token
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: generic
+  data:
+    - secretKey: token
+      remoteRef:
+        key: production/devprod/kargo-argocd-staging-app-reader-token
+        property: token

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/external-secrets/kustomization.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/external-secrets/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - kargo-infra-common-secrets.yaml
+  - argocd-staging-app-reader-token.yaml


### PR DESCRIPTION
Creates a long-lived SA token for the kargo-controller SA on staging so the Kargo HTTP wait-for-revision step can authenticate against the staging cluster API to verify ArgoCD sync status with exact revision matching.

- Add kubernetes.io/service-account-token Secret for kargo-controller SA in kargo-shard-infra-common-deployments (deployed via ArgoCD on staging)
- Add ExternalSecret on prod pulling token from Vault at production/devprod/kargo-argocd-staging-app-reader-token into kargo-infra-common namespace as a Kargo generic credential