### PR TITLE
feat: add argo-rollouts component for internal-staging

### DIFF
--- a/argo-cd-apps/overlays/internal-staging/argo-rollouts.yaml
+++ b/argo-cd-apps/overlays/internal-staging/argo-rollouts.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: argo-rollouts
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/argo-rollouts
+          environment: ""
+  template:
+    metadata:
+      name: argo-rollouts-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-common-deployments.git
+        targetRevision: main
+      destination:
+        namespace: argo-rollouts
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/internal-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/internal-staging/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd-local
 resources:
   - ../../base/all-clusters
   - ../../base/internal
+  - argo-rollouts.yaml
   - dummy-deployment.yaml
   - kargo-shard-infra-common-deployments.yaml
   - kargo-shard-infra-deployments.yaml

--- a/components/argo-rollouts/base/kustomization.yaml
+++ b/components/argo-rollouts/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - rollout-manager.yaml

--- a/components/argo-rollouts/base/namespace.yaml
+++ b/components/argo-rollouts/base/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argo-rollouts
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/components/argo-rollouts/base/rollout-manager.yaml
+++ b/components/argo-rollouts/base/rollout-manager.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: RolloutManager
+metadata:
+  name: argo-rollouts
+  namespace: argo-rollouts
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec: {}

--- a/components/argo-rollouts/internal-production/kustomization.yaml
+++ b/components/argo-rollouts/internal-production/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/components/argo-rollouts/internal-staging/kustomization.yaml
+++ b/components/argo-rollouts/internal-staging/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
Installs Argo Rollouts on the internal-staging cluster via OpenShift GitOps operator RolloutManager CR, following the same pattern as argocd-infra-deployments. Scoped to internal-staging only.