### PR TITLE
feat: add argo-rollouts component for internal-staging (#683)

### DIFF
--- a/components/argo-rollouts/OWNERS
+++ b/components/argo-rollouts/OWNERS
@@ -1,5 +1,3 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
 approvers:
 
 - psturc

--- a/components/argo-rollouts/base/kustomization.yaml
+++ b/components/argo-rollouts/base/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - rbac.yaml
   - rollout-manager.yaml

--- a/components/argo-rollouts/base/rbac.yaml
+++ b/components/argo-rollouts/base/rbac.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rollout-manager-manager
+  namespace: argo-rollouts
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  labels:
+    app.kubernetes.io/part-of: argocd
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rolloutmanagers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rollout-manager-manager
+  namespace: argo-rollouts
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rollout-manager-manager
+subjects:
+  - kind: ServiceAccount
+    name: argocd-argocd-application-controller
+    namespace: argocd-local


### PR DESCRIPTION
Installs Argo Rollouts on the internal-staging cluster via OpenShift GitOps operator RolloutManager CR, following the same pattern as argocd-infra-deployments. Scoped to internal-staging only.

- Add RolloutManager CR with SkipDryRunOnMissingResource to prevent sync failures during operator/CRD bootstrap lag
- Add RBAC for argocd-argocd-application-controller to manage rolloutmanagers in argo-rollouts namespace
- Add OWNERS file with Troy876 added to argo-rollouts and kargo

The error im seeing in Stage is:

```log
one or more objects failed to apply, reason: rolloutmanagers.argoproj.io is forbidden: User "system:serviceaccount:argocd-local:argocd-argocd-application-controller" cannot create resource "rolloutmanagers" in API group "argoproj.io"
  in the namespace "argo-rollouts". Retrying attempt
```