### PR TITLE
KFLUXINFRA-4373 SHA pinning enforcement for GitHub Actions

### DIFF
--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       directories: ${{ steps.list-tests.outputs.directories }}
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - id: list-tests
         run: |
@@ -34,9 +34,9 @@ jobs:
 
     steps:
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Install Dependencies
       shell: bash

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # This prepares directory where github/codeql-action/upload-sarif@v1 looks up report files by default.
       - name: Create ../results directory for SARIF report files
@@ -24,13 +24,13 @@ jobs:
         run: mkdir -p ../results kustomizedfiles
 
       - name: Setup Kustomize
-        uses: multani/action-setup-kustomize@v1
+        uses: multani/action-setup-kustomize@bf96e027caf74ab03bb3f79bac2addb331b28f1d # v1
         with:
           version: '5.7.1'
 
       # Step 1: Try to restore cache
       - name: Cache kustomize builds
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: kustomizedfiles
           key: kustomize-${{ hashFiles('**/kustomization.yaml') }}
@@ -53,7 +53,7 @@ jobs:
             '
 
       - name: Scan yaml files with kube-linter
-        uses: stackrox/kube-linter-action@v1.0.7
+        uses: stackrox/kube-linter-action@87802a2f4e01abebb3ee3c67a3002fea71f6eae5 # v1.0.7
         id: kube-linter-action-scan
         with:
           version: v0.7.6
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF report files to GitHub
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
 
       # Ensure the workflow eventually fails if files did not pass kube-linter checks.
       - name: Verify kube-linter-action succeeded

--- a/.github/workflows/pr-assigner.yaml
+++ b/.github/workflows/pr-assigner.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Assign internal-services assignees from CODEOWNERS
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/test-tekton-kueue-config.yaml
+++ b/.github/workflows/test-tekton-kueue-config.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,7 +10,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Lint yaml manifests
         run: |
           yamllint -f github .


### PR DESCRIPTION
## What

Pin all GitHub Actions to full-length commit SHAs across 5 workflow files.

[KFLUXINFRA-4373](https://redhat.atlassian.net/browse/KFLUXINFRA-4373)

## Why

Organization-level policy "Require actions to be pinned to a full-length commit SHA"
is being enforced on 2026-08-11 08:00 UTC across redhat-appstudio and konflux-ci orgs.
Unpinned actions will cause workflow failures and blocked PRs.

## Changes

| Tag | SHA | Tag Link | Commit Link |
|-----|-----|----------|-------------|
| `actions/checkout@v4` | `11d5960a` | [v4](https://github.com/actions/checkout/releases/tag/v4) | [commit](https://github.com/actions/checkout/commit/11d5960a326750d5838078e36cf38b85af677262) |
| `actions/checkout@v6` | `d23441a4` | [v6](https://github.com/actions/checkout/releases/tag/v6) | [commit](https://github.com/actions/checkout/commit/d23441a48e516b6c34aea4fa41551a30e30af803) |
| `actions/setup-python@v4` | `7f4fc3e2` | [v4](https://github.com/actions/setup-python/releases/tag/v4) | [commit](https://github.com/actions/setup-python/commit/7f4fc3e22c37d6ff65e88745f38bd3157c663f7c) |
| `actions/cache@v4` | `0057852b` | [v4](https://github.com/actions/cache/releases/tag/v4) | [commit](https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830) |
| `actions/github-script@v8` | `ed597411` | [v8](https://github.com/actions/github-script/releases/tag/v8) | [commit](https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd) |
| `github/codeql-action@v3` | `c4dd10e4` | [v3](https://github.com/github/codeql-action/releases/tag/v3) | [commit](https://github.com/github/codeql-action/commit/c4dd10e44af883a891fe31ced449bcb4a6728b9b) |
| `helm/kind-action@v1` | `ef37e7f3` | [v1](https://github.com/helm/kind-action/releases/tag/v1) | [commit](https://github.com/helm/kind-action/commit/ef37e7f390d99f746eb8b610417061a60e82a6cc) |
| `multani/action-setup-kustomize@v1` | `bf96e027` | [v1](https://github.com/multani/action-setup-kustomize/releases/tag/v1) | [commit](https://github.com/multani/action-setup-kustomize/commit/bf96e027caf74ab03bb3f79bac2addb331b28f1d) |
| `stackrox/kube-linter-action@v1.0.7` | `87802a2f` | [v1.0.7](https://github.com/stackrox/kube-linter-action/releases/tag/v1.0.7) | [commit](https://github.com/stackrox/kube-linter-action/commit/87802a2f4e01abebb3ee3c67a3002fea71f6eae5) |

## Validation

- `grep 'uses:' .github/workflows/*.yaml | grep -vE '@[0-9a-f]{40}' → (none)`
- Each SHA verified against its tag via GitHub API

[KFLUXINFRA-4373]: https://redhat.atlassian.net/browse/KFLUXINFRA-4373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ