### PR TITLE
fix(KFLUXDP-1093): Fully enable ssl db connection on grafana resource

### DIFF
--- a/components/konflux-devlake/internal-staging/helm-values.yaml
+++ b/components/konflux-devlake/internal-staging/helm-values.yaml
@@ -124,6 +124,10 @@ grafana:
       secretKeyRef:
         name: konflux-devlake-secrets
         key: GF_AUTH_GOOGLE_CLIENT_SECRET
+    MYSQL_URL:
+      secretKeyRef:
+        name: konflux-devlake-secrets
+        key: MYSQL_URL
   env:
     TZ: "UTC"
     GF_SERVER_SERVE_FROM_SUBPATH: "true"
@@ -142,6 +146,32 @@ grafana:
       allowed_domains: "redhat.com"
       allow_sign_up: true
       auto_login: false
+  datasources:
+    datasource.yml:
+      apiVersion: 1
+      datasources:
+        - name: mysql
+          type: mysql
+          url: $MYSQL_URL
+          database: $MYSQL_DATABASE
+          user: $MYSQL_USER
+          jsonData:
+            tlsAuth: false
+            tlsAuthWithCACert: true
+            tlsSkipVerify: false
+          secureJsonData:
+            password: $MYSQL_PASSWORD
+            tlsCACert: $__file{/etc/ssl/rds/rds-ca-bundle.pem}
+          editable: false
+  extraSecretMounts:
+    - name: rds-ca-certs
+      secretName: konflux-devlake-rds-ca
+      mountPath: /etc/ssl/rds
+      readOnly: true
+      defaultMode: 0440
+      items:
+        - key: AWS_RDS_CRTS
+          path: rds-ca-bundle.pem
 ui:
   image:
     repository: quay.io/konflux-ci/konflux-devprod/devlake-frontend


### PR DESCRIPTION
This is a follow-up to the: https://github.com/redhat-appstudio/infra-common-deployments/pull/692 
To fully enable ssl conection to the Mysql db connection of the Grafana resource.