### PR TITLE
feat(KFLUXDP-1110): implement RBAC viewers for all Kargo projects 

### DIFF
--- a/components/kargo/internal-production/deployment/kargo-helm-generator.yaml
+++ b/components/kargo/internal-production/deployment/kargo-helm-generator.yaml
@@ -33,7 +33,7 @@ valuesInline:
       viewers:
         claims:
           groups:
-          - system:authenticated
+          - system:authenticated:oauth
       dex:
         enabled: true
         image:

--- a/components/kargo/internal-production/projects/base/rbac.yaml
+++ b/components/kargo/internal-production/projects/base/rbac.yaml
@@ -11,3 +11,16 @@ roleRef:
     kind: ClusterRole
     name: kargo-controller-read-secrets
     apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-viewer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated:oauth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-viewer

--- a/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/rbac.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-common/base/rbac/rbac.yaml
@@ -23,3 +23,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: konflux-devprod-kargo-resources-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-viewer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated:oauth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-viewer

--- a/components/kargo/internal-production/projects/kargo-infra-deployments/base/rbac/rbac.yaml
+++ b/components/kargo/internal-production/projects/kargo-infra-deployments/base/rbac/rbac.yaml
@@ -26,3 +26,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: kargo-resources-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-viewer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated:oauth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-viewer

--- a/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
+++ b/components/kargo/internal-staging/deployment/kargo-helm-generator.yaml
@@ -30,6 +30,10 @@ valuesInline:
           - dedicated-admins
           - konflux-infra
           - konflux-devprod
+      viewers:
+        claims:
+          groups:
+          - system:authenticated:oauth
       dex:
         enabled: true
         image:

--- a/components/kargo/internal-staging/projects/base/rbac.yaml
+++ b/components/kargo/internal-staging/projects/base/rbac.yaml
@@ -11,3 +11,16 @@ roleRef:
     kind: ClusterRole
     name: kargo-controller-read-secrets
     apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-viewer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated:oauth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-viewer


### PR DESCRIPTION
- Add kargo-viewer RoleBinding (system:authenticated) to base project RBAC for both staging and production — all authenticated non-admin users can view Stages, Freights, Promotions, Warehouses across all projects
- Add viewers OIDC claim to staging Kargo helm config (production already had it)
