### PR TITLE
KONFLUX-14906: Promote TektonConfig to internal-production

### DIFF
--- a/components/openshift-pipelines/internal-production/kustomization.yaml
+++ b/components/openshift-pipelines/internal-production/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   # Base resources
   - ../base
+  - tekton-config.yaml

--- a/components/openshift-pipelines/internal-production/tekton-config.yaml
+++ b/components/openshift-pipelines/internal-production/tekton-config.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  pipeline:
+    options:
+      configMaps:
+        config-defaults:
+          data:
+            default-imagepullbackoff-timeout: "15m"
+        bundleresolver-config:
+          data:
+            fetch-timeout: "2m"
+            backoff-duration: "15s"
+            backoff-factor: "2.0"
+            backoff-steps: "10"
+            backoff-cap: "15m"
+        git-resolver-config:
+          data:
+            fetch-timeout: "2m"
+  results:
+    disabled: true


### PR DESCRIPTION
## What

- Add TektonConfig resource to `internal-production` overlay with resolver retry backoff and imagepullbackoff timeout settings.

Environments affected: `internal-production`

[KONFLUX-14906](https://issues.redhat.com/browse/KONFLUX-14906)

## Why

The retry configuration for bundle/git resolvers and the imagepullbackoff timeout have been validated in staging and should be promoted to production to improve pipeline resilience.

## Validation

- `kustomize build components/openshift-pipelines/internal-production/` passes
- Staging PR: https://github.com/redhat-appstudio/infra-common-deployments/pull/581

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Misconfigured retry settings could cause pipelines to wait too long before failing. However, these exact settings have been running in staging since PR #581.
**Rollback:** Revert this PR.

Made with [Cursor](https://cursor.com)

[KONFLUX-14906]: https://redhat.atlassian.net/browse/KONFLUX-14906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ