### PR TITLE
feat(kargo-shard): add staging Argo CD app-reader SA for ring-1

### DIFF
--- a/components/kargo-shard/internal-staging/infra-common-deployments/rbac/argocd-app-reader.yaml
+++ b/components/kargo-shard/internal-staging/infra-common-deployments/rbac/argocd-app-reader.yaml
@@ -1,0 +1,46 @@
+---
+# SA used by ring-1 promotions (via Vault → control-plane ExternalSecret) to
+# GET Argo CD Applications from the staging apiserver (kubernetes.default.svc).
+# Role is namespaced to argocd-local (least privilege). Explicit metadata.namespace
+# is set so Argo CD does not fall back to the Application destination namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kargo-infra-common-argocd-app-reader-staging
+  namespace: kargo-shard-infra-common-deployments
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kargo-infra-common-argocd-app-reader-token-staging
+  namespace: kargo-shard-infra-common-deployments
+  annotations:
+    kubernetes.io/service-account.name: kargo-infra-common-argocd-app-reader-staging
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kargo-infra-common-argocd-app-reader-staging
+  namespace: argocd-local
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-infra-common-argocd-app-reader-staging
+  namespace: argocd-local
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kargo-infra-common-argocd-app-reader-staging
+subjects:
+  - kind: ServiceAccount
+    name: kargo-infra-common-argocd-app-reader-staging
+    namespace: kargo-shard-infra-common-deployments

--- a/components/kargo-shard/internal-staging/infra-common-deployments/rbac/kustomization.yaml
+++ b/components/kargo-shard/internal-staging/infra-common-deployments/rbac/kustomization.yaml
@@ -2,7 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - external-secrets
-  - deployment
-  - rbac
+  - argocd-app-reader.yaml


### PR DESCRIPTION
Enable minting a long-lived token on the infra-common staging shard so ring-1 promotions can query argocd-local Applications without racing argocd-wait. RBAC is a Role/RoleBinding in argocd-local (get applications only).